### PR TITLE
feat(macos): route account switches through the Keychain

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -116,6 +116,21 @@ pub(crate) fn read_claude_credentials() -> Result<Option<ClaudeCredentials>> {
     read_json_file(&path).map(Some)
 }
 
+/// macOS: mirror a profile's stored OAuth login into the Keychain so Claude Code
+/// (which reads the Keychain, not the file) actually switches account. No-op when
+/// the profile has no stored `credentials.json` (a base_url profile, whose
+/// endpoint+token come from `settings.json`, or an OAuth profile not yet logged
+/// in) — the existing Keychain login is left untouched in that case.
+#[cfg(target_os = "macos")]
+fn keychain_write_profile(name: &str) -> Result<()> {
+    let path = profile_dir(name)?.join("credentials.json");
+    if !path.exists() {
+        return Ok(());
+    }
+    let creds: ClaudeCredentials = read_json_file(&path)?;
+    crate::keychain::keychain_write(&creds)
+}
+
 #[cfg(unix)]
 pub(crate) fn create_symlink(target: &Path, link: &Path) -> Result<()> {
     std::os::unix::fs::symlink(target, link).context("Failed to create credential symlink")
@@ -164,6 +179,11 @@ pub(crate) fn link_profile_credentials(name: &str) -> Result<()> {
                 std::fs::create_dir_all(parent)?;
             }
             create_symlink(&target, &link)?;
+            // macOS: make the switch real — Claude Code reads the Keychain.
+            #[cfg(target_os = "macos")]
+            if crate::keychain::enabled() {
+                keychain_write_profile(name)?;
+            }
         }
 
         Ok(())
@@ -175,6 +195,12 @@ pub(crate) fn clear_claude_credentials() -> Result<()> {
         let link = claude_credentials_path()?;
         if link.symlink_metadata().is_ok() {
             std::fs::remove_file(&link).context("Failed to remove .credentials.json")?;
+        }
+        // macOS: also drop the live Keychain login so Claude Code can't spend the
+        // account (parity with removing the credential file).
+        #[cfg(target_os = "macos")]
+        if crate::keychain::enabled() {
+            crate::keychain::keychain_delete()?;
         }
         Ok(())
     })
@@ -419,6 +445,11 @@ pub(crate) fn force_link_profile_credentials(name: &str) -> Result<()> {
                 std::fs::create_dir_all(parent)?;
             }
             create_symlink(&target, &link)?;
+            // macOS: make the switch real — Claude Code reads the Keychain.
+            #[cfg(target_os = "macos")]
+            if crate::keychain::enabled() {
+                keychain_write_profile(name)?;
+            }
         }
         Ok(())
     })

--- a/src/keychain.rs
+++ b/src/keychain.rs
@@ -1,0 +1,222 @@
+//! macOS Keychain access for the `Claude Code-credentials` login item.
+//!
+//! Claude Code on macOS stores its OAuth login in the login Keychain (a generic
+//! password: service `Claude Code-credentials`, account = the OS login name), NOT
+//! in `~/.claude/.credentials.json`. So clauth's symlink swap is cosmetic on
+//! macOS unless the switched account is also written here — Claude Code keeps
+//! reading the Keychain.
+//!
+//! **This integration is WRITE-ONLY.** clauth stores every profile as a file
+//! (`~/.clauth/profiles/<name>/credentials.json`); the Keychain is touched ONLY
+//! to make a switch real — a write on switch/link, a delete on clear. clauth does
+//! NOT read the Keychain in any automatic path: reading Claude Code's own item
+//! raises a macOS access prompt on every call, and clauth maintains its own token
+//! chain (via `oauth.rs` rotation) so it never needs to read Claude's. `claude.rs`
+//! wires the write/delete behind `#[cfg(target_os = "macos")]` + [`enabled`].
+//!
+//! **Why the `/usr/bin/security` CLI and not the `security-framework` crate.**
+//! macOS binds a Keychain "Always Allow" grant to the *calling binary's code
+//! signature*. A `cargo build`/`cargo install` binary carries an ad-hoc signature
+//! whose identity changes on every rebuild, so a grant against clauth never
+//! persists — every switch re-prompts. Routing the write through Apple's stable,
+//! code-signed `/usr/bin/security` makes the one-time "Always Allow" bind to
+//! *that* (unchanging) binary, so it sticks permanently and survives clauth
+//! rebuilds — no code-signing dance required. (This is CCSwitcher's approach.)
+
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+use crate::profile::ClaudeCredentials;
+
+/// Apple's Keychain CLI. Absolute path so a hostile `PATH` can't shim it.
+const SECURITY_BIN: &str = "/usr/bin/security";
+
+/// Wall-clock ceiling for a single `security` invocation before it is killed
+/// (TECH-3). A stuck keychain — an unanswered "Always Allow" ACL prompt, a
+/// locked keychain, or a hung home volume — must NOT pin the state flock forever:
+/// the daemon runs the switch (hence this subprocess) inside `with_state_lock` on
+/// its single-threaded run loop, so an unbounded child would wedge auto-switch,
+/// the exact failure the daemon exists to prevent. Generous enough for a real
+/// `add-generic-password`; the watchdog is the coarser backstop above this.
+const SECURITY_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Run `cmd` with a wall-clock deadline, killing (and reaping) the child if it
+/// outlives `timeout`. Returns the collected [`Output`] on a normal exit, or an
+/// error on spawn failure / timeout. Extracted so the deadline is unit-testable
+/// with a benign hanging command (`sleep`) — no real Keychain is touched.
+///
+/// `security` produces only a few bytes of output, so buffering it in the pipe
+/// while we poll cannot deadlock on a full pipe buffer.
+fn run_with_deadline(mut cmd: Command, timeout: Duration) -> Result<Output> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to spawn {SECURITY_BIN}"))?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child
+            .try_wait()
+            .with_context(|| format!("failed to poll {SECURITY_BIN}"))?
+        {
+            Some(_status) => {
+                return child
+                    .wait_with_output()
+                    .with_context(|| format!("failed to collect {SECURITY_BIN} output"));
+            }
+            None => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    anyhow::bail!(
+                        "{SECURITY_BIN} exceeded its {}s deadline and was killed \
+                         (keychain locked or an ACL prompt left unanswered?)",
+                        timeout.as_secs()
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+    }
+}
+
+/// Keychain generic-password service Claude Code reads/writes for its login.
+const SERVICE: &str = "Claude Code-credentials";
+
+/// `security(1)` exit status for `errSecItemNotFound` (-25300). Returned when no
+/// matching item exists; treated as "absent" (`None`) on read and a no-op on delete.
+const EXIT_ITEM_NOT_FOUND: i32 = 44;
+
+/// Whether the live-credential paths in `claude.rs` route through the Keychain.
+/// `true` in the shipped binary; `false` under `cfg(test)` so the test suite
+/// keeps the file/symlink model and NEVER touches the operator's real
+/// `Claude Code-credentials` item. The CLI plumbing itself is covered by the KC-1
+/// round-trip test, which drives `read_at`/`write_at`/`delete_at` on a throwaway
+/// service directly.
+#[cfg(not(test))]
+pub(crate) fn enabled() -> bool {
+    true
+}
+
+#[cfg(test)]
+pub(crate) fn enabled() -> bool {
+    false
+}
+
+/// The Keychain `account` Claude Code stores the login under: the OS login name.
+/// Empirically the login item is at `account = $USER`; a *separate* item at
+/// `account = "unknown"` holds MCP tokens (`mcpOAuth`), not the login — so the
+/// account must be pinned. A bare service-only lookup can return the wrong item.
+fn account() -> Result<String> {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .context("cannot determine macOS login name ($USER/$LOGNAME unset) for Keychain access")
+}
+
+/// Read the credentials JSON stored at `(service, account)` via
+/// `security find-generic-password -w`. `Ok(None)` when the item is absent
+/// (exit 44); any other failure is an error. Test-only: the shipped integration
+/// is write-only (reading Claude's item would prompt on every call). Covered by
+/// the KC-1 round-trip test on a temp service.
+#[cfg(test)]
+fn read_at(service: &str, account: &str) -> Result<Option<ClaudeCredentials>> {
+    let mut cmd = Command::new(SECURITY_BIN);
+    cmd.args(["find-generic-password", "-s", service, "-a", account, "-w"]);
+    let output = run_with_deadline(cmd, SECURITY_TIMEOUT)
+        .with_context(|| format!("failed to run {SECURITY_BIN} find-generic-password"))?;
+    if output.status.success() {
+        // `-w` prints only the password (our JSON) followed by a trailing newline.
+        let json = String::from_utf8(output.stdout).context("Keychain password is not UTF-8")?;
+        let creds: ClaudeCredentials = serde_json::from_str(json.trim_end())
+            .context("Keychain item is not valid Claude credentials JSON")?;
+        Ok(Some(creds))
+    } else if output.status.code() == Some(EXIT_ITEM_NOT_FOUND) {
+        Ok(None)
+    } else {
+        Err(security_error("read", &output))
+    }
+}
+
+/// Add-or-update the item at `(service, account)` with `creds` serialized as the
+/// `{"claudeAiOauth":{…}}` JSON Claude Code expects, via
+/// `security add-generic-password -U`. `-U` updates the item in place when it
+/// already exists (created by Claude Code) and adds it otherwise.
+///
+/// The secret is passed as the `-w` argument, so it is briefly visible in this
+/// user's own process list. Accepted tradeoff (TECH-9 #17): `argv` is readable
+/// only by the SAME UID (or root) on macOS — there is no other-user `ps`
+/// disclosure — and it is the operator's own token on their own machine. A
+/// same-UID process already owns the 0o600 credential files, so racing `ps` to
+/// catch this argv is strictly harder than reading the file. The one residual
+/// sink argv adds over a file read is process-exec logging (Endpoint Security
+/// `es_event_exec_t`, i.e. most EDR agents), which captures full command lines; on
+/// a machine running EDR the token may reach that log store. `security` does have a
+/// no-value `-w` form, but it prompts on the controlling *tty* (`readpassphrase`),
+/// not stdin — a pipe can't feed it — so it is not a usable non-argv path here.
+fn write_at(service: &str, account: &str, creds: &ClaudeCredentials) -> Result<()> {
+    let json = serde_json::to_string(creds).context("failed to serialize Claude credentials")?;
+    let mut cmd = Command::new(SECURITY_BIN);
+    cmd.args([
+        "add-generic-password",
+        "-U",
+        "-s",
+        service,
+        "-a",
+        account,
+        "-w",
+        &json,
+    ]);
+    let output = run_with_deadline(cmd, SECURITY_TIMEOUT)
+        .with_context(|| format!("failed to run {SECURITY_BIN} add-generic-password"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(security_error("write", &output))
+    }
+}
+
+/// Delete the item at `(service, account)` via `security delete-generic-password`.
+/// Idempotent — a missing item (exit 44) is `Ok`.
+fn delete_at(service: &str, account: &str) -> Result<()> {
+    let mut cmd = Command::new(SECURITY_BIN);
+    cmd.args(["delete-generic-password", "-s", service, "-a", account]);
+    let output = run_with_deadline(cmd, SECURITY_TIMEOUT)
+        .with_context(|| format!("failed to run {SECURITY_BIN} delete-generic-password"))?;
+    if output.status.success() || output.status.code() == Some(EXIT_ITEM_NOT_FOUND) {
+        Ok(())
+    } else {
+        Err(security_error("delete", &output))
+    }
+}
+
+/// Build an error from a failed `security` invocation, including its stderr and
+/// exit code (never the password, which is only ever on stdin/argv, not stderr).
+fn security_error(op: &str, output: &std::process::Output) -> anyhow::Error {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let code = output
+        .status
+        .code()
+        .map_or_else(|| "signal".to_string(), |c| c.to_string());
+    anyhow::anyhow!(
+        "Keychain {op} failed (security exit {code}): {}",
+        stderr.trim()
+    )
+}
+
+/// Write `creds` as Claude Code's live OAuth login (add-or-update). This is what
+/// makes an account switch real on macOS: Claude Code reads this on next launch.
+pub(crate) fn keychain_write(creds: &ClaudeCredentials) -> Result<()> {
+    write_at(SERVICE, &account()?, creds)
+}
+
+/// Remove Claude Code's live OAuth login from the Keychain (idempotent).
+pub(crate) fn keychain_delete() -> Result<()> {
+    delete_at(SERVICE, &account()?)
+}
+
+#[cfg(test)]
+#[path = "../tests/inline/keychain.rs"]
+mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,10 @@ mod claude_json;
 mod completions;
 mod fallback;
 mod format;
+// macOS-only: Claude Code reads its login from the Keychain, not the credentials
+// file, so a switch must also write there. Gated so non-macOS builds stay clean.
+#[cfg(target_os = "macos")]
+mod keychain;
 mod lock;
 mod lockorder;
 mod mcp;

--- a/tests/inline/keychain.rs
+++ b/tests/inline/keychain.rs
@@ -1,0 +1,117 @@
+//! KC-1 — Keychain read/write/delete round-trip. Uses a **throwaway service name**
+//! unique to this process; it never touches the real `Claude Code-credentials`
+//! item. It is the ONLY test that drives the real macOS Keychain (via the
+//! `/usr/bin/security` CLI the shipped write/delete path uses), so it is
+//! `#[ignore]`d: it still mutates the login Keychain (creates + deletes a
+//! throwaway item) as a side effect. Run it on demand instead:
+//!     cargo test keychain_round_trip -- --ignored
+//! All other credential/divergence tests stay on the file model
+//! (`keychain::enabled()` is false under `cfg(test)`), so `cargo test` never
+//! touches the Keychain.
+
+use super::{delete_at, read_at, run_with_deadline, write_at};
+use crate::profile::{ClaudeCredentials, OAuthToken};
+
+fn sample_creds(access: &str, refresh: &str) -> ClaudeCredentials {
+    ClaudeCredentials {
+        claude_ai_oauth: Some(OAuthToken {
+            access_token: access.to_string(),
+            refresh_token: Some(refresh.to_string()),
+            expires_at: Some(1_900_000_000_000),
+            scopes: Some(vec![
+                "user:inference".to_string(),
+                "user:profile".to_string(),
+            ]),
+            subscription_type: Some("max".to_string()),
+        }),
+    }
+}
+
+#[test]
+#[ignore = "touches the real login Keychain (throwaway service); macOS re-prompts each rebuild — run explicitly with --ignored"]
+fn keychain_round_trip_on_temp_service() {
+    let service = format!("clauth-test-{}", std::process::id());
+    let account = "clauth-test-account";
+
+    // Clean slate — delete is idempotent, read of an absent item is None.
+    delete_at(&service, account).expect("pre-clean delete is idempotent");
+    assert!(
+        read_at(&service, account).expect("read absent").is_none(),
+        "temp service should start empty"
+    );
+
+    // Write, then read back the same tokens.
+    let creds = sample_creds("sk-ant-oat01-TESTACCESS", "sk-ant-ort01-TESTREFRESH");
+    write_at(&service, account, &creds).expect("write");
+    let oauth = read_at(&service, account)
+        .expect("read present")
+        .expect("some")
+        .claude_ai_oauth
+        .expect("oauth block round-trips");
+    assert_eq!(oauth.access_token, "sk-ant-oat01-TESTACCESS");
+    assert_eq!(
+        oauth.refresh_token.as_deref(),
+        Some("sk-ant-ort01-TESTREFRESH")
+    );
+    assert_eq!(oauth.subscription_type.as_deref(), Some("max"));
+
+    // add-generic-password -U is add-or-update: a second write replaces in place.
+    let updated = sample_creds("sk-ant-oat01-ROTATED", "sk-ant-ort01-ROTATED");
+    write_at(&service, account, &updated).expect("update");
+    let rotated = read_at(&service, account)
+        .expect("read")
+        .expect("some")
+        .claude_ai_oauth
+        .expect("oauth");
+    assert_eq!(rotated.access_token, "sk-ant-oat01-ROTATED");
+
+    // Delete → absent; delete again is still Ok (idempotent).
+    delete_at(&service, account).expect("delete");
+    assert!(
+        read_at(&service, account)
+            .expect("read after delete")
+            .is_none()
+    );
+    delete_at(&service, account).expect("second delete idempotent");
+}
+
+// ── TECH-3: `security` subprocess deadline (no Keychain touched) ───────────────
+//
+// Exercise `run_with_deadline` with benign stand-in commands (`sleep` / `true`)
+// so the timeout-and-kill path is proven without a real `/usr/bin/security`
+// invocation — these run in `cargo test` (unlike the #[ignore]d round-trip).
+
+#[test]
+fn keychain_timeout_kills_a_hung_command() {
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    let mut cmd = Command::new("/bin/sleep");
+    cmd.arg("30");
+    let start = Instant::now();
+    let result = run_with_deadline(cmd, Duration::from_millis(300));
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "a command outrunning its deadline must return an error"
+    );
+    assert!(
+        result.unwrap_err().to_string().contains("deadline"),
+        "the error should name the deadline"
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "the child must be killed near the deadline (was {elapsed:?}), not left to run 30s"
+    );
+}
+
+#[test]
+fn keychain_deadline_returns_output_for_a_fast_command() {
+    use std::process::Command;
+    use std::time::Duration;
+
+    let cmd = Command::new("/usr/bin/true");
+    let out = run_with_deadline(cmd, Duration::from_secs(5)).expect("fast command succeeds");
+    assert!(out.status.success(), "`true` exits 0 within the deadline");
+}


### PR DESCRIPTION
## What

Route macOS account switches through the login **Keychain**, so a switch actually takes effect on a running Claude Code session.

## Why

On macOS, Claude Code reads its OAuth login from the login Keychain — a generic password at service `Claude Code-credentials`, account = the OS login name — **not** from `~/.claude/.credentials.json`. So clauth's symlink swap is cosmetic on macOS: Claude Code keeps reading the Keychain, and the switch silently doesn't apply to a running session. This makes the switch real by mirroring the target profile's stored login into the Keychain (and dropping it on clear).

Follow-on to the merged macOS divergence fix (#4).

## How

- **`src/keychain.rs`** (new) — write / delete Claude Code's login item via Apple's `/usr/bin/security` CLI.
  - **Why the CLI, not the `security-framework` crate:** macOS binds a Keychain *"Always Allow"* grant to the **calling binary's code signature**. A `cargo build` / `cargo install` binary carries an ad-hoc signature that changes on every rebuild, so a grant against clauth never persists — every switch would re-prompt. Routing the write through Apple's stable, code-signed `/usr/bin/security` binds the one-time grant to *that* binary, so it sticks across clauth rebuilds — no code-signing setup required. (Same approach CCSwitcher uses.)
  - A **20 s wall-clock deadline** kills (and reaps) a stuck `security` invocation — an unanswered "Always Allow" ACL prompt or a locked keychain — so it can't wedge the caller while it holds the state lock.
- **`src/claude.rs`** — wires the write on `link_profile_credentials` / `force_link_profile_credentials`, and a delete on `clear_claude_credentials`, each behind `#[cfg(target_os = "macos")]` + `keychain::enabled()`.

## Design notes

- **Write-only.** clauth stores every profile's credentials as a file (`~/.clauth/profiles/<name>/credentials.json`) and never *reads* Claude Code's Keychain item in any automatic path — reading it raises a macOS access prompt on every call. The Keychain is touched only to make a switch real (write on link, delete on clear).
- **No-op when a profile has no stored `credentials.json`** (e.g. a `base_url` profile, or an OAuth profile not yet logged in) — the existing Keychain login is left untouched.
- **macOS-only, cfg-gated.** The `mod keychain;` declaration and all call sites are `#[cfg(target_os = "macos")]`, so non-macOS builds are byte-for-byte unchanged.

## Testing

- `keychain::enabled()` returns `false` under `#[cfg(test)]`, so the whole suite keeps the file/symlink model and **never touches the operator's real `Claude Code-credentials` item**.
- The `KC-1` round-trip test (`tests/inline/keychain.rs`) exercises the real `security` read/write/delete path against a **throwaway, process-unique service name**, and is `#[ignore]`d (it still mutates the login Keychain as a side effect):
  ```
  cargo test keychain_round_trip -- --ignored
  ```
- `cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` are all green (458 passed, 2 ignored). Diff is **+374 / −0**, fully additive.

## Companion project

I've been running this against a macOS menu-bar app that reads the daemon's status feed and drives switches — happy to point at it if a daemon/`status.json` contribution follows.
