### PR TITLE
feat(keychain): feed the write to security -i over stdin — token out of argv

### DIFF
--- a/src/keychain.rs
+++ b/src/keychain.rs
@@ -47,15 +47,39 @@ const SECURITY_TIMEOUT: Duration = Duration::from_secs(20);
 /// error on spawn failure / timeout. Extracted so the deadline is unit-testable
 /// with a benign hanging command (`sleep`) — no real Keychain is touched.
 ///
+/// `stdin_payload`, when given, is written to the child's stdin which is then
+/// closed (EOF) — the transport for `security -i`'s command line, keeping the
+/// secret out of argv. The payload is a few KB and the write happens before the
+/// poll loop; a macOS pipe buffer is 64 KB, so the single write cannot block.
+///
 /// `security` produces only a few bytes of output, so buffering it in the pipe
 /// while we poll cannot deadlock on a full pipe buffer.
-fn run_with_deadline(mut cmd: Command, timeout: Duration) -> Result<Output> {
+fn run_with_deadline(
+    mut cmd: Command,
+    timeout: Duration,
+    stdin_payload: Option<&str>,
+) -> Result<Output> {
     let mut child = cmd
-        .stdin(Stdio::null())
+        .stdin(if stdin_payload.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .with_context(|| format!("failed to spawn {SECURITY_BIN}"))?;
+    if let Some(payload) = stdin_payload {
+        use std::io::Write;
+        let mut stdin = child
+            .stdin
+            .take()
+            .context("child stdin unexpectedly absent")?;
+        stdin
+            .write_all(payload.as_bytes())
+            .with_context(|| format!("failed to write {SECURITY_BIN} stdin"))?;
+        // Dropping the handle closes the pipe — the child sees EOF and runs.
+    }
     let deadline = Instant::now() + timeout;
     loop {
         match child
@@ -125,7 +149,7 @@ fn account() -> Result<String> {
 fn read_at(service: &str, account: &str) -> Result<Option<ClaudeCredentials>> {
     let mut cmd = Command::new(SECURITY_BIN);
     cmd.args(["find-generic-password", "-s", service, "-a", account, "-w"]);
-    let output = run_with_deadline(cmd, SECURITY_TIMEOUT)
+    let output = run_with_deadline(cmd, SECURITY_TIMEOUT, None)
         .with_context(|| format!("failed to run {SECURITY_BIN} find-generic-password"))?;
     if output.status.success() {
         // `-w` prints only the password (our JSON) followed by a trailing newline.
@@ -140,36 +164,52 @@ fn read_at(service: &str, account: &str) -> Result<Option<ClaudeCredentials>> {
     }
 }
 
+/// Quote `s` for `security -i`'s line tokenizer: wrap in `"…"` with `\` → `\\`
+/// and `"` → `\"`. Verified empirically (macOS 15 / Darwin 25): an escaped
+/// quoted string round-trips byte-identical through `add-generic-password -w`,
+/// including embedded spaces, double quotes, and backslashes; an UNquoted value
+/// containing whitespace is split into separate argv words (usage error).
+/// Embedded newlines are refused — `-i` is a line protocol, and a `\n` inside a
+/// value would be parsed as a second command.
+fn security_quote(s: &str) -> Result<String> {
+    if s.contains('\n') || s.contains('\r') {
+        anyhow::bail!("refusing to pass a value with an embedded newline to `security -i`");
+    }
+    Ok(format!(
+        "\"{}\"",
+        s.replace('\\', "\\\\").replace('"', "\\\"")
+    ))
+}
+
 /// Add-or-update the item at `(service, account)` with `creds` serialized as the
 /// `{"claudeAiOauth":{…}}` JSON Claude Code expects, via
 /// `security add-generic-password -U`. `-U` updates the item in place when it
 /// already exists (created by Claude Code) and adds it otherwise.
 ///
-/// The secret is passed as the `-w` argument, so it is briefly visible in this
-/// user's own process list. Accepted tradeoff (TECH-9 #17): `argv` is readable
-/// only by the SAME UID (or root) on macOS — there is no other-user `ps`
-/// disclosure — and it is the operator's own token on their own machine. A
-/// same-UID process already owns the 0o600 credential files, so racing `ps` to
-/// catch this argv is strictly harder than reading the file. The one residual
-/// sink argv adds over a file read is process-exec logging (Endpoint Security
-/// `es_event_exec_t`, i.e. most EDR agents), which captures full command lines; on
-/// a machine running EDR the token may reach that log store. `security` does have a
-/// no-value `-w` form, but it prompts on the controlling *tty* (`readpassphrase`),
-/// not stdin — a pipe can't feed it — so it is not a usable non-argv path here.
+/// The command line is fed to `security -i` over **stdin**, not argv, so the
+/// token never appears in this process's own argv — keeping it out of
+/// process-exec logging (Endpoint Security `es_event_exec_t`, i.e. most EDR
+/// agents), which captures full command lines at exec time but not pipe
+/// contents. (Plain same-UID `ps` exposure was already an accepted tradeoff —
+/// TECH-9 #17: argv is readable only by the same UID or root on macOS, and a
+/// same-UID process already owns the 0o600 credential files — but the EDR log
+/// store was the one residual argv-only sink, and `-i` closes it.) `-i`'s
+/// tokenizer needs the [`security_quote`] escaping for values with whitespace;
+/// the inner command's exit code propagates as `security -i`'s own exit code
+/// (verified: 0 on success, 44 for `errSecItemNotFound`, 2 on usage error).
+/// The no-value `-w` prompt form is still unusable here — it reads from the
+/// controlling *tty* (`readpassphrase`), not stdin, so a pipe can't feed it.
 fn write_at(service: &str, account: &str, creds: &ClaudeCredentials) -> Result<()> {
     let json = serde_json::to_string(creds).context("failed to serialize Claude credentials")?;
+    let line = format!(
+        "add-generic-password -U -s {} -a {} -w {}\n",
+        security_quote(service)?,
+        security_quote(account)?,
+        security_quote(&json)?,
+    );
     let mut cmd = Command::new(SECURITY_BIN);
-    cmd.args([
-        "add-generic-password",
-        "-U",
-        "-s",
-        service,
-        "-a",
-        account,
-        "-w",
-        &json,
-    ]);
-    let output = run_with_deadline(cmd, SECURITY_TIMEOUT)
+    cmd.arg("-i");
+    let output = run_with_deadline(cmd, SECURITY_TIMEOUT, Some(&line))
         .with_context(|| format!("failed to run {SECURITY_BIN} add-generic-password"))?;
     if output.status.success() {
         Ok(())
@@ -183,7 +223,7 @@ fn write_at(service: &str, account: &str, creds: &ClaudeCredentials) -> Result<(
 fn delete_at(service: &str, account: &str) -> Result<()> {
     let mut cmd = Command::new(SECURITY_BIN);
     cmd.args(["delete-generic-password", "-s", service, "-a", account]);
-    let output = run_with_deadline(cmd, SECURITY_TIMEOUT)
+    let output = run_with_deadline(cmd, SECURITY_TIMEOUT, None)
         .with_context(|| format!("failed to run {SECURITY_BIN} delete-generic-password"))?;
     if output.status.success() || output.status.code() == Some(EXIT_ITEM_NOT_FOUND) {
         Ok(())
@@ -193,7 +233,8 @@ fn delete_at(service: &str, account: &str) -> Result<()> {
 }
 
 /// Build an error from a failed `security` invocation, including its stderr and
-/// exit code (never the password, which is only ever on stdin/argv, not stderr).
+/// exit code (never the password, which travels only on the child's stdin —
+/// `write_at` via `security -i` — and is never echoed to stderr).
 fn security_error(op: &str, output: &std::process::Output) -> anyhow::Error {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let code = output

--- a/tests/inline/keychain.rs
+++ b/tests/inline/keychain.rs
@@ -9,7 +9,7 @@
 //! (`keychain::enabled()` is false under `cfg(test)`), so `cargo test` never
 //! touches the Keychain.
 
-use super::{delete_at, read_at, run_with_deadline, write_at};
+use super::{delete_at, read_at, run_with_deadline, security_quote, write_at};
 use crate::profile::{ClaudeCredentials, OAuthToken};
 
 fn sample_creds(access: &str, refresh: &str) -> ClaudeCredentials {
@@ -65,6 +65,19 @@ fn keychain_round_trip_on_temp_service() {
         .expect("oauth");
     assert_eq!(rotated.access_token, "sk-ant-oat01-ROTATED");
 
+    // Hostile-content write via `security -i`: spaces, double quotes, and
+    // backslashes in the secret must round-trip byte-identical through the
+    // security_quote escaping (no real token looks like this; the point is
+    // that the -i tokenizer can never mangle one that does).
+    let hostile = sample_creds(r#"sk with spaces "quoted" back\slash"#, "rt-plain");
+    write_at(&service, account, &hostile).expect("hostile write");
+    let echoed = read_at(&service, account)
+        .expect("read hostile")
+        .expect("some")
+        .claude_ai_oauth
+        .expect("oauth");
+    assert_eq!(echoed.access_token, r#"sk with spaces "quoted" back\slash"#);
+
     // Delete → absent; delete again is still Ok (idempotent).
     delete_at(&service, account).expect("delete");
     assert!(
@@ -89,7 +102,7 @@ fn keychain_timeout_kills_a_hung_command() {
     let mut cmd = Command::new("/bin/sleep");
     cmd.arg("30");
     let start = Instant::now();
-    let result = run_with_deadline(cmd, Duration::from_millis(300));
+    let result = run_with_deadline(cmd, Duration::from_millis(300), None);
     let elapsed = start.elapsed();
 
     assert!(
@@ -112,6 +125,43 @@ fn keychain_deadline_returns_output_for_a_fast_command() {
     use std::time::Duration;
 
     let cmd = Command::new("/usr/bin/true");
-    let out = run_with_deadline(cmd, Duration::from_secs(5)).expect("fast command succeeds");
+    let out = run_with_deadline(cmd, Duration::from_secs(5), None).expect("fast command succeeds");
     assert!(out.status.success(), "`true` exits 0 within the deadline");
+}
+
+// ── `security -i` plumbing: stdin transport + line quoting (no Keychain) ──────
+
+#[test]
+fn deadline_feeds_stdin_payload_and_closes_the_pipe() {
+    use std::process::Command;
+    use std::time::Duration;
+
+    // `cat` exits only when stdin reaches EOF — proves the payload is written
+    // AND the pipe is closed (a leaked handle would hang until the deadline).
+    let cmd = Command::new("/bin/cat");
+    let out = run_with_deadline(cmd, Duration::from_secs(5), Some("payload {\"a b\"}\n"))
+        .expect("cat echoes stdin and exits on EOF");
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "payload {\"a b\"}\n");
+}
+
+#[test]
+fn security_quote_escapes_quotes_backslashes_and_wraps() {
+    assert_eq!(security_quote("plain").expect("quote"), "\"plain\"");
+    assert_eq!(
+        security_quote(r#"{"k": "a b"}"#).expect("quote"),
+        r#""{\"k\": \"a b\"}""#
+    );
+    assert_eq!(
+        security_quote(r"back\slash").expect("quote"),
+        r#""back\\slash""#
+    );
+}
+
+#[test]
+fn security_quote_refuses_embedded_newlines() {
+    // `-i` is a line protocol — a newline inside a value would parse as a
+    // second command. Refusal must be loud, never a silent truncation.
+    assert!(security_quote("a\nb").is_err());
+    assert!(security_quote("a\rb").is_err());
 }


### PR DESCRIPTION
## What

Answers the non-blocking `security -i` question from your #18 review, with on-device data — and since the answer came out clean, ships the switch: the Keychain **write** now feeds its `add-generic-password` line to `security -i` over **stdin**, so the token never appears in argv.

## The empirical answers (macOS 15, throwaway service names only)

Your suspicion was right, but only for the raw form:

- an **unquoted** `-w` value splits on whitespace → usage error, so any payload with spaces dies (compact serde JSON happens to survive, but that's luck, not a contract)
- wrapped in `"…"` with `\` → `\\` and `"` → `\"`, arbitrary JSON — spaces, embedded quotes, backslashes — **round-trips byte-identical**
- `-U` add-or-update behaves identically through `-i`
- the inner command's exit code **propagates** as `security`'s own exit code: `0` success, `44` errSecItemNotFound, `2` usage — so existing error handling keeps working unchanged

One line-protocol caveat: an embedded `\n` in a value would parse as a second command, so `security_quote` refuses it loudly rather than truncating.

## Changes

- **`src/keychain.rs`** — `write_at` builds the command line, quotes each field via the new `security_quote`, and pipes it to `security -i` (`run_with_deadline` grows an `stdin_payload` arg; payload is a few KB, written before the poll loop — a 64 KB pipe buffer can't block it). The argv-tradeoff doc paragraph is replaced with the `-i` rationale + the verified tokenizer rules. `read_at` (test-only) and `delete_at` stay argv — no secret in either. Grant binding unchanged: the caller is still `/usr/bin/security`.
- **`tests/inline/keychain.rs`** — a `/bin/cat` EOF test proves the stdin write + pipe close; `security_quote` unit tests (escaping + newline refusal); the KC-1 `--ignored` round-trip gains a hostile spaces+quotes+backslash secret and was re-run against the real Keychain on a throwaway service — passes.

`cargo test` 578 passed, clippy clean, on this branch.

## Unrelated, spotted while syncing

`clauth --help`'s `login` entry still describes the pre-#19 behavior ("sign in via claude's own /login inside the profile's runtime") — probably worth a one-line refresh whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve4KrFXS5ZhGAxWu2zymrX