### PR TITLE
fix(fallback): weekly (7d) cap hard-blocks a chain member — both directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Most account tools do one half. clauth pairs instant **switching between multipl
 ### Automate & stay safe
 
 - **Automatic token refresh**: OAuth refresh tokens are single-use, so rotation stays lazy. A stale access token rotates the moment a usage query 401s, never ahead of time. <kbd>t</kbd> force-rotates every account.
-- **Auto-switch on exhaustion**: opt accounts into an ordered fallback chain. When the active one crosses its 5h threshold (95% default), clauth hops to the next member with headroom. An opt-in burn-aware mode (Config tab) switches on projected usage instead: heavy burn hops early, light burn rides closer to 100% before moving. Needs clauth open.
+- **Auto-switch on exhaustion**: opt accounts into an ordered fallback chain. When the active one crosses its 5h threshold (95% default), clauth hops to the next member with headroom. Headroom means BOTH windows: a member whose weekly (7d) window is spent to 100% is hard-blocked until its weekly reset — never a switch target, never "recovered" on a 5h rollover, and an active account at the weekly cap counts as exhausted even though its idle 5h window looks empty. An opt-in burn-aware mode (Config tab) switches on projected usage instead: heavy burn hops early, light burn rides closer to 100% before moving. Needs clauth open.
 - **Multi-instance safe**: state writes serialize through a file lock, each instance reloads on external changes, HTTP runs off the UI thread.
 - **In-app help**: <kbd>?</kbd> opens a keybinding reference scoped to the current tab.
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -3,7 +3,9 @@ use anyhow::Result;
 use crate::actions::{switch_off, switch_profile};
 use crate::lock::with_state_lock;
 use crate::profile::{AppConfig, Profile};
-use crate::usage::{UsageStore, UsageWindow, five_hour_live, iso_to_epoch_secs, now_epoch_secs};
+use crate::usage::{
+    UsageStore, UsageWindow, five_hour_live, iso_to_epoch_secs, now_epoch_secs, seven_day_live,
+};
 
 /// What the auto-switch evaluator decided when the active profile crossed its
 /// threshold.
@@ -42,6 +44,36 @@ fn live_five_hour(profile: &Profile) -> Option<&UsageWindow> {
     usage.five_hour.as_ref()
 }
 
+/// Cap at which the OVERALL weekly window hard-blocks an account. Not a
+/// configurable headroom threshold like the 5h one: at 100% the API refuses
+/// requests until the weekly reset, and the idle account's 5h window drains
+/// and then LAPSES — which made a weekly-dead member look like the freshest
+/// target in the chain (observed live 2026-07-08: two members at exactly
+/// 100.0 with no live 5h window, and auto-fallback switched into one). Only
+/// `seven_day` gates here — a per-model `weekly_scoped` limit at 100 (e.g.
+/// "7d fable" spent while 7d has room) blocks just that model, and the walk
+/// cannot know which model the next session will drive.
+const WEEKLY_BLOCK_PCT: f64 = 100.0;
+
+/// Whether `info`'s live weekly window is spent to the cap — unusable until
+/// the weekly reset regardless of anything the 5h window says. Store-side
+/// twin logic inlines this same shape (see `is_exhausted_from_store`).
+fn weekly_blocked_info(info: &crate::usage::UsageInfo, now_secs: i64) -> bool {
+    seven_day_live(info, now_secs)
+        && info
+            .seven_day
+            .as_ref()
+            .is_some_and(|w| w.utilization >= WEEKLY_BLOCK_PCT)
+}
+
+/// [`weekly_blocked_info`] over a profile's own usage snapshot.
+fn weekly_blocked(profile: &Profile) -> bool {
+    profile
+        .usage
+        .as_ref()
+        .is_some_and(|u| weekly_blocked_info(u, now_epoch_secs()))
+}
+
 /// True when the profile's 5h utilization has crossed its own threshold. Also
 /// drives the TUI's all-spent banner wording. Static regardless of burn-aware
 /// mode (issue #8 follow-up b) — the target walk's candidates and
@@ -49,7 +81,8 @@ fn live_five_hour(profile: &Profile) -> Option<&UsageWindow> {
 /// profile's own decision becomes projection-aware (see
 /// [`is_exhausted_active`]).
 pub(crate) fn is_exhausted(profile: &Profile) -> bool {
-    live_five_hour(profile).is_some_and(|w| w.utilization >= threshold_for(profile))
+    weekly_blocked(profile)
+        || live_five_hour(profile).is_some_and(|w| w.utilization >= threshold_for(profile))
 }
 
 /// Recent burn rate (%/h) for `name`'s 5h window: durable per-profile history
@@ -111,6 +144,12 @@ pub(crate) fn is_exhausted_active(
     interval_ms: u64,
     active_burn_pct_per_hour: Option<f64>,
 ) -> bool {
+    // Weekly hard block first: a 7d window at the cap is dead until its
+    // weekly reset whatever the 5h window (often lapsed/idle by then) says,
+    // and no burn projection applies — there is nothing left to project.
+    if weekly_blocked(profile) {
+        return true;
+    }
     let Some(window) = live_five_hour(profile) else {
         return false;
     };
@@ -150,14 +189,15 @@ pub(crate) fn soonest_resume(config: &AppConfig) -> Option<(String, i64)> {
         if !is_exhausted(profile) {
             return None;
         }
-        let resets_at = profile
-            .usage
-            .as_ref()?
-            .five_hour
-            .as_ref()?
-            .resets_at
-            .as_deref()
-            .and_then(iso_to_epoch_secs)?;
+        // A weekly-dead member resumes at its 7d reset (its 5h window may be
+        // lapsed or absent entirely); anyone else at their next 5h reset.
+        let usage = profile.usage.as_ref()?;
+        let window = if weekly_blocked(profile) {
+            usage.seven_day.as_ref()?
+        } else {
+            usage.five_hour.as_ref()?
+        };
+        let resets_at = window.resets_at.as_deref().and_then(iso_to_epoch_secs)?;
         if best.is_none_or(|(_, cur)| resets_at < cur) {
             best = Some((name.as_str(), resets_at));
         }
@@ -240,11 +280,12 @@ fn is_exhausted_from_store(name: &str, threshold: f64, store: &UsageStore) -> bo
     let now = now_epoch_secs();
     match store.lock() {
         Ok(s) => s.get(name).is_some_and(|info| {
-            five_hour_live(info, now)
-                && info
-                    .five_hour
-                    .as_ref()
-                    .is_some_and(|w| w.utilization >= threshold)
+            weekly_blocked_info(info, now)
+                || (five_hour_live(info, now)
+                    && info
+                        .five_hour
+                        .as_ref()
+                        .is_some_and(|w| w.utilization >= threshold))
         }),
         Err(_) => false,
     }
@@ -264,16 +305,25 @@ fn is_exhausted_active_from_store(
     store: &UsageStore,
 ) -> bool {
     let now = now_epoch_secs();
-    let window: Option<UsageWindow> = match store.lock() {
-        Ok(s) => s.get(name).and_then(|info| {
-            if five_hour_live(info, now) {
-                info.five_hour.clone()
-            } else {
-                None
-            }
-        }),
-        Err(_) => None,
+    // One lock window for both reads; weekly hard block trumps projection
+    // (mirrors `is_exhausted_active`).
+    let (blocked, window): (bool, Option<UsageWindow>) = match store.lock() {
+        Ok(s) => match s.get(name) {
+            Some(info) => (
+                weekly_blocked_info(info, now),
+                if five_hour_live(info, now) {
+                    info.five_hour.clone()
+                } else {
+                    None
+                },
+            ),
+            None => (false, None),
+        },
+        Err(_) => (false, None),
     };
+    if blocked {
+        return true;
+    }
     let Some(window) = window else {
         return false;
     };
@@ -441,14 +491,17 @@ pub(crate) fn find_recovered_member(chain: &[ChainMember], store: &UsageStore) -
     for member in chain {
         // A fetched entry whose 5h window is absent or past its reset is idle
         // headroom; a live window recovers only below the member's threshold.
-        // An absent entry (never fetched) stays undecidable.
+        // An absent entry (never fetched) stays undecidable. A weekly-dead
+        // member NEVER recovers — its 5h window lapsing every few hours is
+        // exactly what made it look reborn while the 7d cap still blocks it.
         let recovered = match store.lock() {
             Ok(s) => s.get(&member.name).map(|info| {
-                !five_hour_live(info, now)
-                    || info
-                        .five_hour
-                        .as_ref()
-                        .is_none_or(|w| w.utilization < member.threshold)
+                !weekly_blocked_info(info, now)
+                    && (!five_hour_live(info, now)
+                        || info
+                            .five_hour
+                            .as_ref()
+                            .is_none_or(|w| w.utilization < member.threshold))
             }),
             Err(_) => None,
         };

--- a/src/usage/fetch.rs
+++ b/src/usage/fetch.rs
@@ -928,6 +928,16 @@ pub(crate) fn five_hour_live(info: &UsageInfo, now_secs: i64) -> bool {
         .is_some_and(|resets_at| now_secs < resets_at)
 }
 
+/// [`five_hour_live`] for the OVERALL weekly window: live iff it carries a
+/// parseable reset that is still in the future.
+pub(crate) fn seven_day_live(info: &UsageInfo, now_secs: i64) -> bool {
+    info.seven_day
+        .as_ref()
+        .and_then(|w| w.resets_at.as_deref())
+        .and_then(iso_to_epoch_secs)
+        .is_some_and(|resets_at| now_secs < resets_at)
+}
+
 /// Parse ISO-8601 timestamp (e.g. `2026-05-17T14:20:00.121699+00:00`) into Unix epoch seconds.
 pub(crate) fn iso_to_epoch_secs(s: &str) -> Option<i64> {
     let bytes = s.as_bytes();

--- a/src/usage/mod.rs
+++ b/src/usage/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use fetch::{
     ScopedWindow, SpendInfo, UsageInfo, UsageWindow, WindowDollars, await_request_slot,
     epoch_secs_to_iso, expire_profile_ttl, five_hour_live, http_agent, humanize_duration,
     ideal_pace_pct, iso_to_epoch_secs, now_epoch_secs, now_ms, parse_retry_after,
-    probe_subscription_type, window_avg_pace_per_day,
+    probe_subscription_type, seven_day_live, window_avg_pace_per_day,
 };
 pub(crate) use scheduler::{
     ActivityStore, FetchStatus, LastFetchedAt, NextRefreshPerProfile, OpResult, OpResultReceiver,

--- a/tests/inline/fallback.rs
+++ b/tests/inline/fallback.rs
@@ -947,3 +947,158 @@ fn burn_aware_heavy_burn_flips_wrap_off_decision_on_both_walks() {
         "scheduler-side walk agrees with next_target under burn-aware mode"
     );
 }
+
+// ── weekly hard block (7d at 100%) ────────────────────────────────────────────
+//
+// A weekly-dead account's 5h window drains and then LAPSES (no live reset), so
+// the 5h-only predicates read it as the freshest member in the chain — the
+// observed 2026-07-08 bug: auto-fallback switched INTO a 7d=100 account, and
+// recovery kept relinking it every time its 5h window rolled over.
+
+/// UsageInfo with both windows populated explicitly.
+fn usage_both(five_hour: Option<UsageWindow>, seven_day: Option<UsageWindow>) -> UsageInfo {
+    UsageInfo {
+        five_hour,
+        seven_day,
+        ..UsageInfo::default()
+    }
+}
+
+/// A profile whose weekly window is spent to the cap and whose 5h window has
+/// lapsed entirely — the live specimen's exact shape (5h resets_at: null).
+fn weekly_dead_profile(name: &str) -> Profile {
+    profile_with_usage(
+        name,
+        Some(95.0),
+        Some(usage_both(None, Some(window(100.0, Some(live_reset()))))),
+    )
+}
+
+#[test]
+fn weekly_dead_member_is_never_a_fallback_target() {
+    // a (active, 5h exhausted) → b (7d=100, 5h lapsed) → c (fresh): the walk
+    // must land on c. Before the weekly gate, b's lapsed 5h read as headroom.
+    let config = config_with_chain(
+        vec![
+            profile_with_util("a", Some(95.0), Some(97.0)),
+            weekly_dead_profile("b"),
+            profile_with_util("c", Some(95.0), Some(10.0)),
+        ],
+        "a",
+    );
+    assert_eq!(
+        next_target(&config, None),
+        Some(SwitchAction::To("c".into()))
+    );
+}
+
+#[test]
+fn weekly_dead_active_is_exhausted_despite_idle_5h() {
+    // The mirror direction: an ACTIVE account whose week is spent must count
+    // exhausted — its 5h window never grows again (requests are refused), so
+    // the 5h trigger alone would leave the daemon parked on a dead account.
+    let p = weekly_dead_profile("a");
+    assert!(is_exhausted(&p));
+    // Hard block trumps both burn-aware modes (nothing left to project).
+    assert!(is_exhausted_active(&p, false, 90_000, None));
+    assert!(is_exhausted_active(&p, true, 90_000, Some(5.0)));
+}
+
+#[test]
+fn weekly_below_cap_or_lapsed_does_not_block() {
+    // 99.9% still serves requests — only the cap blocks. The 5h side has
+    // threshold semantics; the weekly side is a hard-block check by design.
+    let almost = profile_with_usage(
+        "a",
+        Some(95.0),
+        Some(usage_both(None, Some(window(99.9, Some(live_reset()))))),
+    );
+    assert!(!is_exhausted(&almost));
+    // A 7d=100 whose reset has PASSED is a renewed quota, not a block.
+    let renewed = profile_with_usage(
+        "a",
+        Some(95.0),
+        Some(usage_both(None, Some(window(100.0, Some(expired_reset()))))),
+    );
+    assert!(!is_exhausted(&renewed));
+}
+
+#[test]
+fn weekly_dead_member_is_skipped_by_the_store_walk_too() {
+    // Scheduler-side twin: next_auto_switch_target reads the UsageStore.
+    let config = config_with_chain(
+        vec![
+            profile_with_util("a", Some(95.0), None),
+            profile_with_util("b", Some(95.0), None),
+            profile_with_util("c", Some(95.0), None),
+        ],
+        "a",
+    );
+    let snapshot = snapshot_chain(&config).expect("snapshot");
+    let store = store_with_infos(vec![
+        ("a", usage_info(Some(window(97.0, Some(live_reset()))))),
+        (
+            "b",
+            usage_both(None, Some(window(100.0, Some(live_reset())))),
+        ),
+        ("c", usage_info(Some(window(10.0, Some(live_reset()))))),
+    ]);
+    assert_eq!(
+        next_auto_switch_target(&snapshot, &store),
+        Some(SwitchAction::To("c".into()))
+    );
+}
+
+#[test]
+fn weekly_dead_member_never_recovers() {
+    // Recovery's "5h lapsed = idle headroom" rule is exactly how a weekly-dead
+    // member kept getting relinked every 5h rollover. It must stay out until
+    // the WEEKLY reset passes.
+    let members = vec![ChainMember {
+        name: "b".into(),
+        threshold: 95.0,
+        last_resort: false,
+    }];
+    let dead = store_with_infos(vec![(
+        "b",
+        usage_both(None, Some(window(100.0, Some(live_reset())))),
+    )]);
+    assert_eq!(find_recovered_member(&members, &dead), None);
+    // Same member with the weekly reset in the past HAS recovered.
+    let renewed = store_with_infos(vec![(
+        "b",
+        usage_both(None, Some(window(100.0, Some(expired_reset())))),
+    )]);
+    assert_eq!(
+        find_recovered_member(&members, &renewed),
+        Some("b".to_string())
+    );
+}
+
+#[test]
+fn soonest_resume_uses_the_weekly_reset_for_a_weekly_dead_member() {
+    // The all-exhausted caption must not promise a 5h comeback for an account
+    // that is blocked until its WEEKLY reset (nor bail to no caption at all
+    // because the 5h window is absent).
+    let weekly_reset = epoch_secs_to_iso(now_epoch_secs() + 48 * 3600);
+    let five_hour_reset = epoch_secs_to_iso(now_epoch_secs() + 600);
+    let config = config_with_chain(
+        vec![
+            profile_with_usage(
+                "a",
+                Some(95.0),
+                Some(usage_both(Some(window(97.0, Some(five_hour_reset))), None)),
+            ),
+            profile_with_usage(
+                "b",
+                Some(95.0),
+                Some(usage_both(None, Some(window(100.0, Some(weekly_reset))))),
+            ),
+        ],
+        "a",
+    );
+    let (name, secs) = soonest_resume(&config).expect("caption data");
+    // a's 10-minute 5h reset beats b's 48h weekly reset.
+    assert_eq!(name, "a");
+    assert!((500..700).contains(&secs), "got {secs}");
+}


### PR DESCRIPTION
Found on-device 2026-07-08, and upstream has the same hole (`fallback.rs` never reads `seven_day`): **auto-switch rotated INTO an account whose weekly window was spent to 100%.**

## Why the walk loves dead accounts

A weekly-capped account is the pathological case for 5h-only exhaustion logic: the API refuses its requests, so its 5h window drains and then **lapses entirely** (`resets_at: null`) — which every predicate reads as *fresh headroom*. On my machine two chain members sat at exactly `7d = 100.0` with no live 5h window; the walk targeted one, and `find_recovered_member` re-linked weekly-dead members on every 5h rollover ("5h lapsed = recovered").

## Fix

A LIVE overall `seven_day` window at ≥ 100% (`WEEKLY_BLOCK_PCT`) counts the account exhausted in every predicate — profile-side and store-side, the target walk and the ACTIVE side (where the hard block precedes the burn-aware projection: there is nothing left to project), and recovery never picks a weekly-dead member. `soonest_resume` reports the WEEKLY reset for such members instead of bailing on their absent 5h window, so the all-exhausted caption stays truthful.

Deliberately a **hard-block check, not a threshold**: 99.9% still serves requests, and a 7d=100 whose reset has passed is a renewed quota. Only the overall `seven_day` window gates — a per-model `weekly_scoped` limit at 100 (e.g. a model-scoped weekly spent while 7d has room) blocks just that model, and the walk can't know which model the next session will drive.

## Tests

595 total (6 new): never-a-target, active-side exhaustion despite an idle 5h window, below-cap/lapsed-reset headroom, the store-side walk twin, never-recovers (+ recovers once the weekly reset passes), and the soonest-resume caption. Clippy + rustfmt clean.

Heads-up: overlaps #24/#25 in `fallback.rs`/`scheduler.rs` context — happy to rebase in whatever order you land them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)