### PR TITLE
fix(scheduler): a retry-after:0 429 must ride the backoff ladder

### DIFF
--- a/src/usage/scheduler.rs
+++ b/src/usage/scheduler.rs
@@ -521,25 +521,28 @@ fn rate_limit_backoff_ms(streak: u32) -> u64 {
 }
 
 /// Deferral added to a profile's `last_fetched` stamp so `partition_due`'s fixed
-/// `stamp + interval` math lands the next slot correctly. A server `retry-after`
-/// defers to `now + retry_after` (capped) — an explicit `0` / elapsed date
-/// (parsed as `ZERO`) means "retry now", so it lands the normal cadence rather
-/// than the no-hint ladder. A 429 with no header at all defers one interval +
-/// [`rate_limit_backoff_ms`] (which grows with the consecutive-429 `streak`),
-/// capped at [`MAX_RETRY_AFTER_MS`]. Everything else: no defer.
+/// `stamp + interval` math lands the next slot correctly. On a 429 the slot is
+/// `max(server retry-after, one interval + `[`rate_limit_backoff_ms`]`)` —
+/// a REAL long hint is honored verbatim, but a `0` / sub-cadence hint can
+/// never suppress the streak ladder. The usage endpoint answers EVERY 429
+/// with `retry-after: 0` while its sliding window counts the rejected
+/// requests too; taking that "retry now" at face value re-polls at cadence,
+/// keeps the window pinned full, and the profile never leaves `RateLimited`
+/// (observed 2026-07-11: hours of uninterrupted per-account 429s that only a
+/// growing back-off can drain). Capped at [`MAX_RETRY_AFTER_MS`]. Non-429
+/// outcomes: no defer.
 fn next_slot_deferral(
     rate_limited: bool,
     retry_after: Option<Duration>,
     streak: u32,
     interval_ms: u64,
 ) -> IntervalMs {
-    let target_ms = match retry_after.map(|ra| ra.as_millis() as u64) {
-        // Honor any server hint verbatim, including an explicit `0`: the server
-        // said "retry now", so cadence — never escalate it into the no-hint
-        // exponential backoff below (that ladder is only for a missing header).
-        Some(ms) => ms,
-        None if rate_limited => interval_ms.saturating_add(rate_limit_backoff_ms(streak)),
-        None => 0,
+    let hint = retry_after.map(|ra| ra.as_millis() as u64);
+    let target_ms = if rate_limited {
+        let ladder = interval_ms.saturating_add(rate_limit_backoff_ms(streak));
+        hint.unwrap_or(0).max(ladder)
+    } else {
+        hint.unwrap_or(0)
     };
     IntervalMs::from_millis(
         target_ms

--- a/tests/inline/scheduler.rs
+++ b/tests/inline/scheduler.rs
@@ -548,7 +548,7 @@ fn retry_after_defers_next_fetch_slot() {
         "a 429 with no retry-after defers a flat 10s past now"
     );
 
-    // Hint shorter than the interval → no extra deferral.
+    // Hint shorter than the ladder → the ladder wins (max, never suppressed).
     let before = now_ms();
     apply_outcome(
         outcome("c", Some(Duration::from_secs(5))),
@@ -559,7 +559,10 @@ fn retry_after_defers_next_fetch_slot() {
         REFRESH_INTERVAL_MS,
     );
     let after = now_ms();
-    assert!((before..=after).contains(&stamp("c")));
+    assert!(
+        (before + floor..=after + floor).contains(&stamp("c")),
+        "a sub-cadence hint cannot undercut the streak ladder"
+    );
 
     // Absurd hint → clamped to the ceiling.
     let before = now_ms();
@@ -578,9 +581,11 @@ fn retry_after_defers_next_fetch_slot() {
         "huge retry-after clamps to MAX_RETRY_AFTER_MS"
     );
 
-    // Explicit `retry-after: 0` (server says "retry now", same as an elapsed
-    // HTTP-date) keeps the cadence — it must NOT fall into the no-hint
-    // exponential backoff that a missing header gets.
+    // Explicit `retry-after: 0` rides the SAME ladder as a missing header.
+    // The usage endpoint answers every 429 with `retry-after: 0` while its
+    // sliding window counts the rejected requests too — honoring the "retry
+    // now" verbatim re-polls at cadence and pins the window full forever
+    // (observed 2026-07-11: hours of uninterrupted per-account 429s).
     let before = now_ms();
     apply_outcome(
         outcome("e", Some(Duration::ZERO)),
@@ -592,8 +597,8 @@ fn retry_after_defers_next_fetch_slot() {
     );
     let after = now_ms();
     assert!(
-        (before..=after).contains(&stamp("e")),
-        "a zero retry-after keeps the cadence, never escalates to backoff"
+        (before + floor..=after + floor).contains(&stamp("e")),
+        "a zero retry-after must not suppress the backoff ladder"
     );
 }
 


### PR DESCRIPTION
The exponential 429 ladder (`rate_limit_backoff_ms` × streak) only engaged when the `retry-after` header was MISSING; an explicit hint was honored verbatim — including `0`. The usage endpoint answers **every** 429 with `retry-after: 0`, and its sliding window counts the rejected requests too. So once an account crosses the limit, "honor the 0, retry at cadence" keeps the window pinned full and the profile never leaves `RateLimited`.

Observed live (2026-07-11, macOS, three OAuth profiles): two accounts pinned `RateLimited` for ~50 minutes across daemon restarts — every poll 429 `retry-after: 0` — while a freshly re-logged third account fetched 200 from the same IP in the same tick (so per-account, not endpoint-wide). What crossed the line in the first place: several clauth instances open at once (each TUI runs its own full scheduler), i.e. 2–3× the 90s cadence per account for a day. Four minutes after deploying this fix, both accounts were `Fresh` again — one ladder-spaced retry was enough to drain the window.

The rule is now: on a 429, deferral = `max(server hint, interval + ladder)`. A real long hint still wins verbatim; a `0`/sub-cadence hint can never suppress the ladder. Non-429 behavior unchanged. The two tests that pinned the old "a zero keeps the cadence" contract are updated to pin the new one, with the incident as the comment trail.

Note on CI/test noise: `runtime::tests::has_live_session_*` / `live_session_count_*` / `sync_credentials_unlocked_concurrent_*` flake under parallel load on the CLEAN v0.9.0 base on my machine (fail-alive probe reads one transient error as "alive") — unrelated to this diff; settled-poll hardening for two of them already rides #24/#25.

627 tests, clippy + rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)