### PR TITLE
feat(tui): non-blocking divergence banner + "switch to the login's owner" resolver action

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -472,6 +472,35 @@ pub(crate) fn set_profile_default_model(
     edit_profile_model(config, name, models)
 }
 
+/// Which profile the CURRENT live login (`~/.claude/.credentials.json`)
+/// belongs to, by exact token match — no network:
+///
+/// **Exact token match** (refresh or access token equal to a profile's stored
+/// pair): the live file IS that profile's credential — a stale mirror, or a
+/// half-landed switch that moved the link but not the state.
+///
+/// Returns the owning profile's name — possibly the ACTIVE profile itself (a
+/// same-account divergence, which the adopt path self-heals). Callers wanting a
+/// SIBLING must compare against the active name. `None` when the login matches
+/// no stored token — either a genuinely foreign account (a human decision) or a
+/// CC re-login where every token is new. An account-uuid tier (CC's own
+/// `~/.claude.json` identity record matched against a profile's cached identity
+/// anchor) can layer on once per-profile identity anchors exist (PR #24); until
+/// then this is token-equality only.
+pub(crate) fn identify_live_login_owner(config: &AppConfig) -> Option<String> {
+    let live = read_claude_credentials().ok().flatten()?;
+    let live_access = live.access_token().filter(|t| !t.is_empty());
+    let live_refresh = live.refresh_token().filter(|t| !t.is_empty());
+    config
+        .profiles
+        .iter()
+        .find(|p| {
+            (live_refresh.is_some() && p.refresh_token() == live_refresh)
+                || (live_access.is_some() && p.access_token() == live_access)
+        })
+        .map(|p| p.name.as_str().to_string())
+}
+
 /// Returns a profile whose `refresh_token` matches `live`. Matches on refresh
 /// token only (stable identity); access tokens rotate and would produce false
 /// misses and duplicate profiles.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -388,22 +388,60 @@ pub(crate) struct CaptureNameForm {
     pub(crate) from_divergence: bool,
 }
 
-/// Credential-divergence prompt. Shown at startup and on the 1Hz poll when
-/// `.credentials.json` no longer matches the active profile's stored creds.
-/// Three actions: Overwrite, NewProfile, or Discard.
+/// Credential-divergence prompt. Raised on demand (the <kbd>d</kbd> key from
+/// the non-blocking banner) and when an action that REQUIRES resolution is
+/// attempted (switch / switch-off / plugin fix) — never auto-pushed at startup
+/// or from the 1Hz poll, so a divergence can't lock the whole TUI
+/// (`divergence_pending` + the banner carry the signal instead).
 #[derive(Debug, Clone)]
 pub(crate) struct DivergenceForm {
     pub(crate) active: String,
+    /// The profile the live login was identified as belonging to
+    /// ([`crate::actions::identify_live_login_owner`], local evidence), when
+    /// that profile is NOT the active one. Surfaces a first-class "switch to
+    /// it" action — the near-always-right resolution for a CC re-login into a
+    /// known account, which the generic three options all get wrong.
+    pub(crate) sibling: Option<String>,
     pub(crate) cursor: usize,
 }
 
+/// The non-blocking divergence signal behind the accounts-pane banner: set by
+/// the 1Hz poll / startup reconcile, cleared the moment the live link matches
+/// again. <kbd>d</kbd> opens the resolver from it.
+#[derive(Debug, Clone)]
+pub(crate) struct DivergenceNotice {
+    pub(crate) active: String,
+    /// Locally identified owner of the live login when it is a NON-active
+    /// profile (see [`DivergenceForm::sibling`]); drives the banner wording.
+    pub(crate) sibling: Option<String>,
+    /// SipHash of the live access token at identification time — the memo that
+    /// keeps the 1Hz poll from re-running the owner lookup while the live login
+    /// is unchanged.
+    pub(crate) fingerprint: Option<u64>,
+}
+
+/// One row on the Divergence prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DivergenceAction {
+    /// The live login belongs to this (non-active) profile: capture it there
+    /// and make that profile active — the [`ConfirmAction::AdoptDivergence`]
+    /// path the "save elsewhere" picker already uses, promoted to the top.
+    SwitchToOwner(String),
+    Choice(DivergenceChoice),
+}
+
 impl DivergenceForm {
-    pub(crate) fn options() -> [DivergenceChoice; 3] {
-        [
-            DivergenceChoice::Overwrite,
-            DivergenceChoice::NewProfile,
-            DivergenceChoice::Discard,
-        ]
+    pub(crate) fn actions(&self) -> Vec<DivergenceAction> {
+        let mut v = Vec::with_capacity(4);
+        if let Some(owner) = &self.sibling {
+            v.push(DivergenceAction::SwitchToOwner(owner.clone()));
+        }
+        v.extend([
+            DivergenceAction::Choice(DivergenceChoice::Overwrite),
+            DivergenceAction::Choice(DivergenceChoice::NewProfile),
+            DivergenceAction::Choice(DivergenceChoice::Discard),
+        ]);
+        v
     }
 }
 
@@ -1233,11 +1271,12 @@ pub(crate) struct App {
     pub(crate) banner: Option<Banner>,
     /// Last time the 1Hz divergence poll ran.
     pub(crate) last_divergence_check: Instant,
-    /// Fingerprint of a divergence the user dismissed with esc (siphash of the
-    /// live access token). The poll stays quiet while the live login still
-    /// hashes to this; a fresh `/login` or refresh changes it and re-prompts
-    /// once. In-memory only — a restart re-evaluates.
-    pub(crate) divergence_snooze: Option<u64>,
+    /// The non-blocking divergence banner's backing signal: `Some` while the
+    /// live login no longer matches the active profile, `None` the moment the
+    /// link is clean again. Set/refreshed by the 1Hz poll and startup
+    /// reconcile; <kbd>d</kbd> opens the resolver from it. In-memory only — a
+    /// restart re-evaluates.
+    pub(crate) divergence_pending: Option<DivergenceNotice>,
     /// Throttle for the Plugin tab's per-tick live refresh (session counts + link
     /// state); recompute fires at most once per `PLUGIN_REFRESH_INTERVAL`.
     pub(crate) last_plugin_refresh: Instant,
@@ -1478,7 +1517,7 @@ impl App {
             footer_alert: None,
             banner: None,
             last_divergence_check: Instant::now(),
-            divergence_snooze: None,
+            divergence_pending: None,
             last_plugin_refresh: Instant::now(),
             reconcile_done: false,
             bootstrap_started: false,
@@ -2158,6 +2197,15 @@ pub(crate) fn handle_key(app: &mut App, key: KeyEvent) {
             app.modals.push(Modal::Help);
             return;
         }
+        KeyCode::Char('d') => {
+            // Open the divergence resolver from the banner (no-op when the
+            // live link is clean).
+            if let Some(notice) = app.divergence_pending.clone() {
+                app.disarm_quit();
+                open_divergence_modal(app, &notice.active);
+            }
+            return;
+        }
         KeyCode::Char('a') => {
             app.disarm_quit();
             let state = build_action_menu(app);
@@ -2559,10 +2607,7 @@ fn apply_plugin_fix(app: &mut App) {
         }
         PluginFix::RepairDivergence(name) => {
             app.disarm_quit();
-            app.modals.push(Modal::Divergence(DivergenceForm {
-                active: name,
-                cursor: 0,
-            }));
+            open_divergence_modal(app, &name);
         }
         PluginFix::RelinkCredentials(name) => {
             app.disarm_quit();
@@ -3075,8 +3120,23 @@ fn prompt_divergence(app: &mut App, active: String, verb: &str) {
         ToastKind::Warning,
         format!("'{active}' has unsaved Claude Code credentials; resolve before {verb}"),
     );
-    app.modals
-        .push(Modal::Divergence(DivergenceForm { active, cursor: 0 }));
+    open_divergence_modal(app, &active);
+}
+
+/// Push the Divergence prompt, first identifying (locally) which profile the
+/// live login belongs to so the near-always-right "switch to it" action can
+/// lead the menu. The active profile owning its own newer login is NOT a
+/// sibling (that is the adopt path's self-healing domain).
+fn open_divergence_modal(app: &mut App, active: &str) {
+    let sibling = {
+        let cfg = app.config();
+        crate::actions::identify_live_login_owner(&cfg).filter(|owner| owner != active)
+    };
+    app.modals.push(Modal::Divergence(DivergenceForm {
+        active: active.to_string(),
+        sibling,
+        cursor: 0,
+    }));
 }
 
 /// Synchronous UI-thread switch. No HTTP; clears the Switching marker, runs
@@ -5574,8 +5634,8 @@ fn handle_divergence_key(app: &mut App, key: KeyEvent) {
     let Some(Modal::Divergence(state)) = app.modals.last_mut() else {
         return;
     };
-    let options = DivergenceForm::options();
-    let last = options.len() - 1;
+    let actions = state.actions();
+    let last = actions.len() - 1;
     match key.code {
         KeyCode::Up => {
             state.cursor = if state.cursor == 0 {
@@ -5592,16 +5652,34 @@ fn handle_divergence_key(app: &mut App, key: KeyEvent) {
             };
         }
         KeyCode::Esc | KeyCode::Char('q') => {
-            // Snooze this exact live login so the 1Hz poll stops re-pushing; a
-            // fresh login or refresh changes the fingerprint and re-prompts.
-            app.divergence_snooze = live_creds_fingerprint();
+            // Just close — the prompt is on-demand now; the non-blocking
+            // banner keeps carrying the signal until the divergence resolves.
             app.modals.pop();
         }
         KeyCode::Enter | KeyCode::Char(' ') => {
-            let choice = options[state.cursor];
+            let action = actions[state.cursor.min(last)].clone();
             let active = state.active.clone();
             app.modals.pop();
-            run_divergence_choice(app, &active, choice);
+            match action {
+                DivergenceAction::SwitchToOwner(owner) => {
+                    // Same confirmed path as the "save elsewhere" picker: the
+                    // live login is captured into its own profile, which then
+                    // becomes active. Nothing is lost, nothing else rewritten.
+                    let Some(snapshot) = capture_live_or_toast(app) else {
+                        return;
+                    };
+                    app.modals.push(Modal::Confirm(ConfirmState {
+                        message: format!("Switch to '{owner}' — the live login is its account?"),
+                        detail: Some(format!(
+                            "The login is saved into '{owner}' and '{owner}' becomes the active \
+                             account. The running claude is untouched."
+                        )),
+                        choice: false,
+                        on_confirm: ConfirmAction::AdoptDivergence(Box::new(snapshot), owner),
+                    }));
+                }
+                DivergenceAction::Choice(choice) => run_divergence_choice(app, &active, choice),
+            }
         }
         _ => {}
     }
@@ -6278,8 +6356,11 @@ fn drain_startup_signals(app: &mut App) {
                 if let Some(choice) = default {
                     run_divergence_choice(app, &active, choice);
                 } else {
-                    app.modals
-                        .push(Modal::Divergence(DivergenceForm { active, cursor: 0 }));
+                    // Non-blocking: flag the banner; the user opens the
+                    // resolver with <kbd>d</kbd> when they want it, and any
+                    // switch-shaped action raises it itself. Startup must never
+                    // lock the TUI behind a modal.
+                    note_divergence(app, &active);
                 }
             }
             StartupSignal::BootstrapDone => {
@@ -6299,8 +6380,13 @@ fn maybe_spawn_bootstrap(app: &mut App) {
     app.spawn_bootstrap();
 }
 
-/// 1Hz check: push Divergence modal if `.credentials.json` no longer matches
-/// the active profile's stored creds. Skips when a modal is already open.
+/// 1Hz check: keep [`App::divergence_pending`] (the non-blocking banner) in
+/// sync with whether `.credentials.json` matches the active profile's stored
+/// creds. Never pushes the modal — a divergence must not lock the whole TUI out
+/// of browsing usage; <kbd>d</kbd> opens the resolver on demand, and
+/// switch-shaped actions raise it themselves when resolution is actually
+/// required. First-login adoption and a configured `default_divergence` still
+/// resolve automatically here.
 fn poll_credentials_divergence(app: &mut App) {
     const POLL_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -6319,13 +6405,14 @@ fn poll_credentials_divergence(app: &mut App) {
         .as_deref()
         .map(str::to_string)
     else {
+        app.divergence_pending = None;
         return;
     };
     if !matches!(
         classify_credentials_link(&active).ok(),
         Some(LinkState::Diverged)
     ) {
-        app.divergence_snooze = None; // resolved; a later divergence re-prompts
+        app.divergence_pending = None; // resolved; a later divergence re-flags
         return;
     }
     // First login on a credential-less profile: adopt silently, don't prompt.
@@ -6349,19 +6436,34 @@ fn poll_credentials_divergence(app: &mut App) {
         run_divergence_choice(app, &active, choice);
         return;
     }
-    // Dismissed already and the live login hasn't changed since — stay quiet.
+    note_divergence(app, &active);
+}
+
+/// Set/refresh the non-blocking divergence banner. The (local) owner lookup
+/// runs only when the live login actually changed — the fingerprint memo keeps
+/// the 1Hz poll to a single file read in the steady state.
+fn note_divergence(app: &mut App, active: &str) {
     let fingerprint = live_creds_fingerprint();
-    if fingerprint.is_some() && fingerprint == app.divergence_snooze {
+    if let Some(p) = &app.divergence_pending
+        && p.active == active
+        && p.fingerprint == fingerprint
+    {
         return;
     }
-    app.divergence_snooze = None;
-    app.modals
-        .push(Modal::Divergence(DivergenceForm { active, cursor: 0 }));
+    let sibling = {
+        let cfg = app.config();
+        crate::actions::identify_live_login_owner(&cfg).filter(|owner| owner != active)
+    };
+    app.divergence_pending = Some(DivergenceNotice {
+        active: active.to_string(),
+        sibling,
+        fingerprint,
+    });
 }
 
 /// SipHash of the live access token — a cheap identity for "which login sits in
 /// `~/.claude/.credentials.json` right now". It changes on every re-login and
-/// every refresh, so a snooze keyed to it releases exactly when the creds
+/// every refresh, so the banner's owner lookup re-runs exactly when the creds
 /// change. `None` when no readable OAuth login is present.
 fn live_creds_fingerprint() -> Option<u64> {
     use std::hash::{DefaultHasher, Hash, Hasher};

--- a/src/tui/render/modals.rs
+++ b/src/tui/render/modals.rs
@@ -10,8 +10,8 @@ use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph};
 use crate::profile::DivergenceChoice;
 
 use super::super::app::{
-    ActionMenuState, App, ConfirmAction, ConfirmState, DivergenceForm, DivergenceTargetForm,
-    EnvCollisionChoice, EnvCollisionForm, InputState, LoginStage, Modal, Tab,
+    ActionMenuState, App, ConfirmAction, ConfirmState, DivergenceAction, DivergenceForm,
+    DivergenceTargetForm, EnvCollisionChoice, EnvCollisionForm, InputState, LoginStage, Modal, Tab,
 };
 use super::super::theme;
 use super::format::spinner_frame;
@@ -207,37 +207,54 @@ fn danger_button(label: &str, focused: bool) -> Span<'static> {
 }
 
 fn draw_divergence(frame: &mut Frame<'_>, area: Rect, form: &DivergenceForm) {
-    let options = DivergenceForm::options();
-    let cursor = form.cursor.min(options.len() - 1);
+    let actions = form.actions();
+    let cursor = form.cursor.min(actions.len() - 1);
 
-    let mut lines: Vec<Line<'_>> = vec![
-        Line::from(vec![
-            Span::styled("the live login no longer matches ", theme::dim()),
+    let mut lines: Vec<Line<'_>> = vec![Line::from(vec![
+        Span::styled("the live login no longer matches ", theme::dim()),
+        Span::styled(
+            format!("'{}'", form.active),
+            Style::default().fg(theme::accent_color()),
+        ),
+        Span::styled(".", theme::dim()),
+    ])];
+    if let Some(owner) = &form.sibling {
+        lines.push(Line::from(vec![
+            Span::styled("it is ", theme::dim()),
             Span::styled(
-                format!("'{}'", form.active),
+                format!("'{owner}'"),
                 Style::default().fg(theme::accent_color()),
             ),
-            Span::styled(".", theme::dim()),
-        ]),
-        Line::from(""),
-    ];
+            Span::styled("'s login.", theme::dim()),
+        ]));
+    }
+    lines.push(Line::from(""));
 
-    for (i, option) in options.iter().enumerate() {
+    for (i, action) in actions.iter().enumerate() {
         let selected = i == cursor;
         lines.push(option_line(
             selected,
-            divergence_option_text(*option, &form.active),
+            divergence_action_text(action, &form.active),
         ));
     }
 
     draw_modal(frame, area, "DIVERGENCE", lines);
 }
 
-fn divergence_option_text(option: DivergenceChoice, active: &str) -> String {
-    match option {
-        DivergenceChoice::Overwrite => format!("overwrite '{active}' with this login"),
-        DivergenceChoice::NewProfile => "save this login to another profile…".to_string(),
-        DivergenceChoice::Discard => format!("discard this login and restore '{active}'"),
+fn divergence_action_text(action: &DivergenceAction, active: &str) -> String {
+    match action {
+        DivergenceAction::SwitchToOwner(owner) => {
+            format!("switch to '{owner}' — this login is its account")
+        }
+        DivergenceAction::Choice(DivergenceChoice::Overwrite) => {
+            format!("overwrite '{active}' with this login")
+        }
+        DivergenceAction::Choice(DivergenceChoice::NewProfile) => {
+            "save this login to another profile…".to_string()
+        }
+        DivergenceAction::Choice(DivergenceChoice::Discard) => {
+            format!("discard this login and restore '{active}'")
+        }
     }
 }
 
@@ -483,6 +500,7 @@ fn draw_help(frame: &mut Frame<'_>, area: Rect, app: &App) {
         ("n", "new account"),
         ("r", "refresh usage now"),
         ("t", "rotate all tokens"),
+        ("d", "resolve credential divergence (when flagged)"),
         ("?", "toggle this help"),
         ("a", "actions"),
         ("x", "dismiss toast / alert"),

--- a/src/tui/render/overview.rs
+++ b/src/tui/render/overview.rs
@@ -45,6 +45,22 @@ fn draw_overview_accounts(frame: &mut Frame<'_>, area: Rect, app: &App) {
         return;
     }
 
+    // Non-blocking divergence banner: one warning line above the table, in
+    // place of the modal that used to lock the whole TUI at startup. The rest
+    // of the screen (usage, tabs, actions) stays fully usable.
+    let banner = app.divergence_pending.as_ref().map(divergence_banner);
+    let inner = match banner {
+        Some(line) => {
+            let split = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(1), Constraint::Min(1)])
+                .split(inner);
+            frame.render_widget(Paragraph::new(line).style(theme::base()), split[0]);
+            split[1]
+        }
+        None => inner,
+    };
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(1), Constraint::Min(1)])
@@ -77,6 +93,42 @@ fn draw_overview_accounts(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
     let viewport = chunks[1].height as usize;
     draw_scrollbar(frame, chunks[1], total, state.offset(), viewport);
+}
+
+/// The one-line divergence warning. Sibling identified → say whose login it is;
+/// unknown → the generic mismatch. Both end in the `d` affordance.
+fn divergence_banner(notice: &super::super::app::DivergenceNotice) -> Line<'static> {
+    let mut spans = vec![Span::styled("\u{26a0} ", theme::warning())];
+    match &notice.sibling {
+        Some(owner) => {
+            spans.push(Span::styled("live login is ", theme::warning()));
+            spans.push(Span::styled(
+                format!("'{owner}'"),
+                Style::default()
+                    .fg(theme::accent_color())
+                    .add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::styled(
+                format!(" — not the active '{}'", notice.active),
+                theme::warning(),
+            ));
+        }
+        None => {
+            spans.push(Span::styled(
+                format!("live login no longer matches '{}'", notice.active),
+                theme::warning(),
+            ));
+        }
+    }
+    spans.push(Span::styled("  ·  press ", theme::dim()));
+    spans.push(Span::styled(
+        "d",
+        Style::default()
+            .fg(theme::accent_color())
+            .add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(" to resolve", theme::dim()));
+    Line::from(spans)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/tests/inline/actions.rs
+++ b/tests/inline/actions.rs
@@ -752,3 +752,79 @@ fn oauth_creds(access: &str) -> crate::profile::ClaudeCredentials {
         }),
     }
 }
+
+// ── identify_live_login_owner: whose login sits in ~/.claude right now ──────
+//
+// Token-equality tier only. An account-uuid tier (CC's `~/.claude.json`
+// identity record matched against a profile's cached anchor) layers on once
+// per-profile identity anchors exist (PR #24) — no anchors upstream yet.
+
+#[cfg(unix)]
+mod identify_live_login_owner {
+    use crate::profile::{AppConfig, AppState, ClaudeCredentials, OAuthToken, Profile};
+    use crate::testutil::HomeSandbox;
+
+    fn creds(access: &str, refresh: &str) -> ClaudeCredentials {
+        ClaudeCredentials {
+            claude_ai_oauth: Some(OAuthToken {
+                access_token: access.to_string(),
+                refresh_token: Some(refresh.to_string()),
+                expires_at: None,
+                scopes: None,
+                subscription_type: None,
+            }),
+        }
+    }
+
+    fn config_with(profiles: Vec<(&str, ClaudeCredentials)>) -> AppConfig {
+        let profiles: Vec<Profile> = profiles
+            .into_iter()
+            .map(|(name, c)| {
+                let mut p = Profile::new(name.to_string(), None, None);
+                p.credentials = Some(c);
+                p
+            })
+            .collect();
+        AppConfig {
+            state: AppState {
+                profiles: profiles.iter().map(|p| p.name.clone()).collect(),
+                ..AppState::default()
+            },
+            profiles,
+        }
+    }
+
+    fn write_live(c: &ClaudeCredentials) {
+        let live = crate::profile::claude_dir()
+            .expect("claude dir")
+            .join(".credentials.json");
+        std::fs::create_dir_all(live.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&live, serde_json::to_vec(c).expect("ser")).expect("write");
+    }
+
+    /// Exact token equality — the live file IS a profile's stored credential
+    /// (stale mirror / half-landed switch).
+    #[test]
+    fn exact_token_match_identifies_the_owner() {
+        let _home = HomeSandbox::new();
+        let cfg = config_with(vec![
+            ("a", creds("at-a", "rt-a")),
+            ("b", creds("at-b", "rt-b")),
+        ]);
+        write_live(&creds("at-b", "rt-b"));
+        assert_eq!(
+            crate::actions::identify_live_login_owner(&cfg).as_deref(),
+            Some("b")
+        );
+    }
+
+    /// No token match → unknown; a CC re-login where every token is new (no
+    /// anchors yet) and a genuinely foreign account both identify nobody.
+    #[test]
+    fn a_foreign_login_identifies_nobody() {
+        let _home = HomeSandbox::new();
+        let cfg = config_with(vec![("a", creds("at-a", "rt-a"))]);
+        write_live(&creds("at-foreign", "rt-foreign"));
+        assert_eq!(crate::actions::identify_live_login_owner(&cfg), None);
+    }
+}

--- a/tests/inline/tui_app.rs
+++ b/tests/inline/tui_app.rs
@@ -769,12 +769,13 @@ fn relogin_gate_maps_divergence_defaults() {
     );
 }
 
-// Issue #20: dismissing the divergence prompt must stop the 1Hz poll from
-// re-pushing it every second. The snooze releases only when the live login
-// itself changes (a fresh /login or refresh), so a stale account isn't nagged
-// forever yet a genuinely new one still surfaces.
+// A divergence must never lock the TUI: the 1Hz poll raises the non-blocking
+// BANNER (`divergence_pending`), never the modal — browsing usage stays fully
+// available. <kbd>d</kbd> opens the resolver on demand; Esc closes it and, with
+// no auto-push left, nothing re-raises it. (Supersedes the issue #20 snooze:
+// with no auto-push there is nothing to snooze.)
 #[test]
-fn divergence_dismiss_snoozes_until_the_live_login_changes() {
+fn divergence_flags_the_banner_and_never_blocks_the_tui() {
     use super::{Modal, handle_key};
     use crate::profile::{AppConfig, AppState, Profile, save_profile};
     use crate::testutil::key;
@@ -796,26 +797,89 @@ fn divergence_dismiss_snoozes_until_the_live_login_changes() {
 
     force_poll(&mut app);
     assert!(
-        matches!(app.modals.last(), Some(Modal::Divergence(_))),
-        "a diverged active profile prompts"
-    );
-
-    handle_key(&mut app, key(KeyCode::Esc));
-    assert!(app.modals.is_empty(), "esc dismisses the prompt");
-    assert!(app.divergence_snooze.is_some(), "esc records a snooze");
-
-    force_poll(&mut app);
-    assert!(
         app.modals.is_empty(),
-        "the same dismissed login must not re-prompt"
+        "the poll must NOT raise the modal — a divergence can't lock the TUI"
+    );
+    let notice = app
+        .divergence_pending
+        .clone()
+        .expect("the poll flags the banner instead");
+    assert_eq!(notice.active, "work");
+    assert_eq!(
+        notice.sibling, None,
+        "an unknown login has no owner to offer"
     );
 
-    // A fresh login (new access token, same or different account) re-prompts.
-    write_live_creds(&creds_ra("rt-live", "at-2"));
-    force_poll(&mut app);
+    // `d` opens the resolver on demand; Esc closes it and nothing re-raises.
+    handle_key(&mut app, key(KeyCode::Char('d')));
     assert!(
         matches!(app.modals.last(), Some(Modal::Divergence(_))),
-        "a changed live login re-prompts once"
+        "d opens the resolver from the banner"
+    );
+    handle_key(&mut app, key(KeyCode::Esc));
+    assert!(app.modals.is_empty(), "esc dismisses the resolver");
+    force_poll(&mut app);
+    assert!(app.modals.is_empty(), "no auto-re-raise after dismissal");
+
+    // The link healing clears the banner (and `d` becomes a no-op).
+    crate::claude::force_link_profile_credentials("work").expect("relink");
+    force_poll(&mut app);
+    assert!(
+        app.divergence_pending.is_none(),
+        "a clean link clears the banner"
+    );
+    handle_key(&mut app, key(KeyCode::Char('d')));
+    assert!(app.modals.is_empty(), "d is a no-op with no divergence");
+}
+
+/// The banner and the resolver both identify the live login's OWNER when it is
+/// a stored sibling — by exact token match here (the half-landed-switch shape)
+/// — and the resolver leads with the "switch to it" action.
+#[test]
+fn divergence_identifies_a_sibling_owner_and_leads_with_switch_to_it() {
+    use super::{DivergenceAction, Modal, handle_key};
+    use crate::profile::{AppConfig, AppState, DivergenceChoice, Profile, save_profile};
+    use crate::testutil::key;
+    use ratatui::crossterm::event::KeyCode;
+    let _home = crate::testutil::HomeSandbox::new();
+
+    let mut work = Profile::new("work".to_string(), None, None);
+    work.credentials = Some(login_creds("rt-work"));
+    save_profile(&work).expect("save work");
+    let mut play = Profile::new("play".to_string(), None, None);
+    play.credentials = Some(creds_ra("rt-play", "at-play"));
+    save_profile(&play).expect("save play");
+    // The live file carries play's EXACT stored pair while work is active.
+    write_live_creds(&creds_ra("rt-play", "at-play"));
+
+    let mut app = App::new(AppConfig {
+        state: AppState {
+            active_profile: Some("work".into()),
+            profiles: vec!["work".into(), "play".into()],
+            ..AppState::default()
+        },
+        profiles: vec![work, play],
+    });
+
+    force_poll(&mut app);
+    let notice = app.divergence_pending.clone().expect("banner flagged");
+    assert_eq!(notice.sibling.as_deref(), Some("play"));
+
+    handle_key(&mut app, key(KeyCode::Char('d')));
+    let Some(Modal::Divergence(form)) = app.modals.last() else {
+        panic!("d opens the resolver");
+    };
+    assert_eq!(form.sibling.as_deref(), Some("play"));
+    let actions = form.actions();
+    assert_eq!(
+        actions.first(),
+        Some(&DivergenceAction::SwitchToOwner("play".to_string())),
+        "the owner switch leads the menu"
+    );
+    assert_eq!(actions.len(), 4, "the three generic choices follow");
+    assert_eq!(
+        actions[1],
+        DivergenceAction::Choice(DivergenceChoice::Overwrite)
     );
 }
 


### PR DESCRIPTION
Fixes #29.

**1. A divergence no longer locks the TUI.** The 1Hz poll and the startup reconcile stop pushing the `DIVERGENCE` modal; they set `divergence_pending` and render a one-line warning banner over the accounts table — `⚠ live login no longer matches 'x' · press d to resolve` (naming the owner when identified). <kbd>d</kbd> opens the resolver on demand; switch-shaped actions (switch, switch-off, the Plugin tab's repair fix) still raise it themselves, because those genuinely require a decision. First-login silent adoption and a configured `default_divergence` keep auto-resolving exactly as before. The #20 snooze is superseded — with no auto-push there is nothing to snooze (its test is replaced by two pinning the new contract).

**2. The resolver recognizes a login clauth already holds.** `identify_live_login_owner` names the live login's owner by exact token match (refresh or access token equal to a profile's stored pair — the stale-mirror / half-landed-switch shape). When the owner is a NON-active profile, the resolver leads with a fourth, first-positioned action: *switch to '<owner>' — this login is its account*, which routes through the existing confirmed `AdoptDivergence` path (capture into its own profile, make it active — nothing lost, nothing else rewritten). The banner names the owner too.

The owner lookup is deliberately local-evidence-only and token-tier-only here. An account-uuid tier (Claude Code's own `~/.claude.json` identity record matched against a per-profile identity anchor — catches a re-login where every token is new) layers on naturally once #24's identity anchors land; happy to follow up with it after that merges.

630 tests (5 new: banner-not-modal contract, sibling-leads-the-menu, owner identification ×3), clippy + rustfmt clean; the one parallel-run failure on my machine is the pre-existing `runtime::tests` fail-alive flake noted on #30 (serial run: 630/630).

🤖 Generated with [Claude Code](https://claude.com/claude-code)