### PR TITLE
fix(tui): fixed_split silently drops one char at the truncation boundary

### DIFF
--- a/src/tui/render/format.rs
+++ b/src/tui/render/format.rs
@@ -20,15 +20,17 @@ pub(super) fn fixed(value: &str, width: usize) -> String {
 pub(super) fn fixed_split(value: &str, width: usize) -> (String, String) {
     let mut content = String::with_capacity(width);
     let mut count = 0;
-    let mut iter = value.chars();
-    for ch in iter.by_ref() {
-        if count >= width {
-            break;
-        }
+    // Peek instead of a plain `for`: the loop head must not consume the char
+    // AFTER the window, or a value exactly one char over `width` reads as
+    // exhausted and gets silently cropped with no ellipsis
+    // ("Max 20x" at 6 → "Max 20" instead of "Max 2…").
+    let mut iter = value.chars().peekable();
+    while count < width {
+        let Some(ch) = iter.next() else { break };
         content.push(ch);
         count += 1;
     }
-    if width > 0 && iter.next().is_some() {
+    if width > 0 && iter.peek().is_some() {
         content.pop();
         content.push('…');
         count = width;
@@ -36,6 +38,10 @@ pub(super) fn fixed_split(value: &str, width: usize) -> (String, String) {
     let pad = " ".repeat(width - count);
     (content, pad)
 }
+
+#[cfg(test)]
+#[path = "../../../tests/inline/tui_render_format.rs"]
+mod tests;
 
 pub(super) fn name_style(profile: &Profile) -> Style {
     let base = Style::default().fg(theme::text_color());

--- a/tests/inline/tui_render_format.rs
+++ b/tests/inline/tui_render_format.rs
@@ -1,0 +1,54 @@
+//! `fixed_split` truncation contract: content + pad always total `width`, and
+//! ANY dropped character is signalled with a trailing `…` — including the
+//! boundary case where the value is exactly one char over the window, which
+//! the old `for`-loop consumed and mistook for end-of-string.
+
+use super::*;
+
+fn joined(value: &str, width: usize) -> String {
+    let (content, pad) = fixed_split(value, width);
+    format!("{content}{pad}")
+}
+
+#[test]
+fn fits_exactly_no_ellipsis() {
+    assert_eq!(fixed_split("Max 20", 6), ("Max 20".into(), "".into()));
+}
+
+#[test]
+fn shorter_pads_to_width() {
+    assert_eq!(fixed_split("ok", 5), ("ok".into(), "   ".into()));
+}
+
+/// The off-by-one: one char over the window must still truncate visibly.
+#[test]
+fn one_char_over_truncates_with_ellipsis() {
+    assert_eq!(fixed_split("Max 20x", 6).0, "Max 2…");
+    assert_eq!(fixed_split("x@computelabs.ai", 15).0, "x@computelabs.…");
+}
+
+#[test]
+fn far_over_truncates_with_ellipsis() {
+    assert_eq!(fixed_split("a-long-account-name", 8).0, "a-long-…");
+}
+
+#[test]
+fn width_zero_yields_nothing() {
+    assert_eq!(fixed_split("anything", 0), (String::new(), String::new()));
+}
+
+/// Invariant across the boundary: rendered cell is always exactly `width`
+/// chars for any non-empty value.
+#[test]
+fn cell_is_always_exactly_width() {
+    for len in 0..12usize {
+        let value: String = "abcdefghijkl".chars().take(len).collect();
+        for width in 1..10usize {
+            assert_eq!(
+                joined(&value, width).chars().count(),
+                width,
+                "value len {len}, width {width}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## The bug

`fixed_split`'s `for ch in iter.by_ref()` checks `count >= width` at the top of the body — **after** the iterator has already yielded the char. So for a value exactly one char over the window, the overflow char is consumed by the loop head, the follow-up `iter.next()` sees an exhausted iterator, and no ellipsis is added: the cell renders `width` chars with one char silently cropped.

Concrete: the overview's `type` column at its 6-wide band renders `"Max 20x"` as **`Max 20`** — a plausible-but-wrong tier (reads as Max 20, is Max 20x) — instead of `Max 2…`. Same for any name/label/email exactly one char over its column: you get a valid-looking wrong string with no truncation cue, which is worse than an honest ellipsis.

## The fix

Peek instead of consume: a `while count < width` loop pulls only chars inside the window, and the ellipsis check uses `iter.peek()`. Any dropped character now always surfaces as `…`.

## Tests

New `tests/inline/tui_render_format.rs`:
- the boundary case (`"Max 20x"` @ 6 → `"Max 2…"`, and a 16-char email @ 15),
- exact-fit / shorter / far-over / width-0 behavior unchanged,
- a small property sweep pinning `content + pad` at exactly `width` chars for value lengths 0–12 × widths 1–9.

709 tests green on `mommy`, clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)