### PR TITLE
fix(tui): overview gap widening overflows the row — 5h column clipped at narrow widths

### DIFF
--- a/src/tui/render/overview.rs
+++ b/src/tui/render/overview.rs
@@ -156,7 +156,11 @@ impl OverviewWidths {
         let base = fixed_overview_width(name, kind, five_hour, seven_day, route, gap_min);
         let column_count = 3 + usize::from(seven_day > 0) + usize::from(route > 0);
         let gap_slots = column_count.saturating_sub(1).max(1);
-        let gap = (gap_min + total.saturating_sub(base) / gap_slots).clamp(gap_min, 8);
+        // `fixed_overview_width` omits the TIMER_SLOT the row always renders;
+        // widening gaps from that undercounted figure overflows the row at
+        // narrow widths and clips the tail of the 5h column. Widen from the
+        // real leftover instead.
+        let gap = (gap_min + total.saturating_sub(base + TIMER_SLOT) / gap_slots).clamp(gap_min, 8);
 
         Self {
             name,

--- a/tests/inline/tui_render_overview.rs
+++ b/tests/inline/tui_render_overview.rs
@@ -118,3 +118,34 @@ fn healthy_chain_hides_resumes_hint() {
     let lines = fallback_flow_lines(&app, 60, 20);
     assert!(resumes_line(&lines).is_none());
 }
+
+/// Gap widening must work from the row's REAL width. `fixed_overview_width`
+/// omits the TIMER_SLOT the row always renders, and widening gaps from that
+/// undercounted figure overflows the row at narrow widths, clipping the tail
+/// of the 5h column (observed at a 50-column pane: `[░░░░░]  0` with the `%`
+/// pushed off-screen). Whenever the columns fit at all at minimum gaps, the
+/// gap-widened layout must still fit.
+#[test]
+fn gap_widening_never_clips_the_row() {
+    let a = profile("ax-main", 95.0, 10.0, 3600);
+    let b = profile("ax-backup", 95.0, 20.0, 3600);
+    let config = config_with(vec![a, b], Some("ax-main"), vec![]);
+    let app = App::new(config);
+    for width in 34u16..=200 {
+        let w = OverviewWidths::new(width, &app);
+        let min =
+            fixed_overview_width(w.name, w.kind, w.five_hour, w.seven_day, w.route, 2) + TIMER_SLOT;
+        if min > width as usize {
+            // Below this the shrink loop has already bottomed out and the row
+            // deliberately overflows-and-clips; gap widening isn't the cause.
+            continue;
+        }
+        let used = fixed_overview_width(w.name, w.kind, w.five_hour, w.seven_day, w.route, w.gap)
+            + TIMER_SLOT;
+        assert!(
+            used <= width as usize,
+            "row overflows at width {width}: used {used} (gap {})",
+            w.gap
+        );
+    }
+}


### PR DESCRIPTION
## The bug

`fixed_overview_width` deliberately doesn't count the TIMER_SLOT (5 cells) the row always renders — the comment says "Timer slot is in the gap before 5h, not a column". But the elastic-gap widening measures its spare against that same undercounted figure:

```rust
let gap = (gap_min + total.saturating_sub(base) / gap_slots).clamp(gap_min, 8);
```

so at widths where the phantom 5 cells matter, the widened row is wider than the pane and ratatui clips the tail. Reproduce: 3 accounts, a 50-column terminal (48 inner) — the 5h cell renders

```
│ ❯   ax-cl            Max 20     22s [░░░░░]  0 │
```

with the `%` pushed off-screen (content is 48+2 wide). The `clamp(…, 8)` hides the undercount at most widths, which is why it only bites in a narrow band.

## The fix

Widen from the real leftover:

```rust
let gap = (gap_min + total.saturating_sub(base + TIMER_SLOT) / gap_slots).clamp(gap_min, 8);
```

At the 50-col pane the gap settles at 5 instead of 8 and the row fits exactly:

```
│ ❯ ● ax-cl         Max 20x  59s [█░░░░] 17%      │
```

## Test

`gap_widening_never_clips_the_row` sweeps every width 34..=200: whenever the columns fit at minimum gaps at all (below that the shrink loop has already bottomed out and clipping is deliberate), the gap-widened layout must also fit including TIMER_SLOT. The test is red on `mommy` (first failure at width 39: used 41 with gap 4) and green with the fix. 704 tests green, clippy/fmt clean.

Independent of #32 (different file); found while making a narrow-terminal layout change on the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
