### PR TITLE
fix(auth): ensure_installable re-reads token state under the RotationGuard

### DIFF
--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1017,40 +1017,16 @@ pub(crate) fn ensure_installable(
     name: &str,
     refresher: impl Fn(&str) -> std::result::Result<TokenResponse, RefreshError>,
 ) -> AuthGate {
-    // Read the target's auth shape under the config lock, then release it — the
-    // HTTP refresh below must never hold the config mutex (a slow refresh would
-    // otherwise wedge the daemon's single-threaded run loop).
-    let (expires_at, refresh_token, flagged) = {
-        let Ok(cfg) = config.lock() else {
-            return AuthGate::Transient(anyhow::anyhow!("config mutex poisoned"));
-        };
-        let Some(profile) = cfg.find(name) else {
-            // Unknown profile: nothing to gate — the switch itself surfaces
-            // "Profile not found".
-            return AuthGate::Ready;
-        };
-        if !profile.is_oauth() {
-            // Third-party (api-key) profiles carry no OAuth token to expire.
+    // Cheap pre-check WITHOUT the rotation guard: non-OAuth and
+    // comfortably-live tokens install as-is. Token data read here is
+    // discarded — only the post-guard re-read may feed the refresher (a
+    // pre-guard snapshot can go stale the moment a sibling rotation runs).
+    match oauth_shape(config, name) {
+        Err(gate) => return gate,
+        Ok((expires_at, _, flagged)) if !expiring(expires_at, flagged) => {
             return AuthGate::Ready;
         }
-        (
-            profile.access_token_expires_at(),
-            profile.refresh_token().map(str::to_string),
-            cfg.is_auth_broken(name),
-        )
-    };
-
-    // Unknown expiry → treat as not-expiring (mirrors `auto_start_kick`): install
-    // as-is and let the lazy 401→rotate path handle a surprise expiry. A standing
-    // `auth_broken` flag overrides the clock: the chain's last refresh terminally
-    // failed, so a still-future `expires_at` proves nothing (server-side
-    // revocation outlives the stored clock). Route it through the refresher —
-    // a recovered chain comes back `Refreshed` and lifts the flag, a dead one
-    // confirms `Broken`.
-    let expiring =
-        flagged || expires_at.is_some_and(|exp| (now_ms() as i64) + AUTH_GATE_GRACE_MS >= exp);
-    if !expiring {
-        return AuthGate::Ready;
+        Ok(_) => {}
     }
 
     // RotationGuard across the HTTP window (single-use double-spend guard),
@@ -1065,6 +1041,74 @@ pub(crate) fn ensure_installable(
     // advances this profile's single-use chain and keeps the Keychain fresh, so
     // refreshing here would 400 the session — install as-is.
     if has_live_session(name) {
+        return AuthGate::Ready;
+    }
+    gate_under_guard(config, name, refresher)
+}
+
+/// The target's auth shape — `(access-token expiry, refresh token, standing
+/// auth_broken flag)` — read under the config lock and released before
+/// returning, so no caller ever holds the mutex across an HTTP refresh. `Err`
+/// carries the gate verdict for the non-OAuth / unknown-profile / poisoned
+/// cases.
+#[allow(
+    clippy::type_complexity,
+    reason = "one-shot triple, named at both call sites"
+)]
+fn oauth_shape(
+    config: &crate::profile::ConfigHandle,
+    name: &str,
+) -> std::result::Result<(Option<i64>, Option<String>, bool), AuthGate> {
+    let Ok(cfg) = config.lock() else {
+        return Err(AuthGate::Transient(anyhow::anyhow!(
+            "config mutex poisoned"
+        )));
+    };
+    let Some(profile) = cfg.find(name) else {
+        // Unknown profile: nothing to gate — the switch itself surfaces
+        // "Profile not found".
+        return Err(AuthGate::Ready);
+    };
+    if !profile.is_oauth() {
+        // Third-party (api-key) profiles carry no OAuth token to expire.
+        return Err(AuthGate::Ready);
+    }
+    Ok((
+        profile.access_token_expires_at(),
+        profile.refresh_token().map(str::to_string),
+        cfg.is_auth_broken(name),
+    ))
+}
+
+/// Unknown expiry → treated as not-expiring (mirrors `auto_start_kick`):
+/// install as-is and let the lazy 401→rotate path handle a surprise expiry.
+/// A standing `auth_broken` flag overrides the clock: the chain's last refresh
+/// terminally failed, so a still-future `expires_at` proves nothing
+/// (server-side revocation outlives the stored clock). Route it through the
+/// refresher — a recovered chain comes back `Refreshed` and lifts the flag, a
+/// dead one confirms `Broken`.
+fn expiring(expires_at: Option<i64>, flagged: bool) -> bool {
+    flagged || expires_at.is_some_and(|exp| (now_ms() as i64) + AUTH_GATE_GRACE_MS >= exp)
+}
+
+/// The refresh leg, entered only with the [`RotationGuard`] held. Re-reads the
+/// auth shape UNDER the guard — between the pre-check and guard acquisition a
+/// sibling rotation may have spent the single-use refresh token and persisted
+/// a new pair, and refreshing from that stale snapshot would 400 and wrongly
+/// quarantine a healthy login. This function takes no token arguments, so
+/// post-guard decisions structurally cannot reuse pre-guard data.
+fn gate_under_guard(
+    config: &crate::profile::ConfigHandle,
+    name: &str,
+    refresher: impl Fn(&str) -> std::result::Result<TokenResponse, RefreshError>,
+) -> AuthGate {
+    let (expires_at, refresh_token, flagged) = match oauth_shape(config, name) {
+        Err(gate) => return gate,
+        Ok(shape) => shape,
+    };
+    if !expiring(expires_at, flagged) {
+        // A sibling refreshed while we acquired the guard — the stored pair is
+        // fresh; install it as-is instead of double-spending the old chain.
         return AuthGate::Ready;
     }
     let Some(rt) = refresh_token else {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1032,7 +1032,7 @@ pub(crate) fn ensure_installable(
     // RotationGuard across the HTTP window (single-use double-spend guard),
     // acquired with no config lock held. A busy guard means a live session or
     // sibling worker is already on this chain — refuse this switch and retry.
-    let Ok(_guard) = RotationGuard::acquire(name) else {
+    let Ok(guard) = RotationGuard::acquire(name) else {
         return AuthGate::Transient(anyhow::anyhow!(
             "'{name}' rotation lock busy; retry after the in-flight refresh"
         ));
@@ -1043,7 +1043,7 @@ pub(crate) fn ensure_installable(
     if has_live_session(name) {
         return AuthGate::Ready;
     }
-    gate_under_guard(config, name, refresher)
+    gate_under_guard(config, name, refresher, &guard)
 }
 
 /// The target's auth shape — `(access-token expiry, refresh token, standing
@@ -1091,17 +1091,55 @@ fn expiring(expires_at: Option<i64>, flagged: bool) -> bool {
     flagged || expires_at.is_some_and(|exp| (now_ms() as i64) + AUTH_GATE_GRACE_MS >= exp)
 }
 
-/// The refresh leg, entered only with the [`RotationGuard`] held. Re-reads the
-/// auth shape UNDER the guard — between the pre-check and guard acquisition a
-/// sibling rotation may have spent the single-use refresh token and persisted
-/// a new pair, and refreshing from that stale snapshot would 400 and wrongly
-/// quarantine a healthy login. This function takes no token arguments, so
-/// post-guard decisions structurally cannot reuse pre-guard data.
+/// Reconcile the in-memory profile with the on-disk store; the `_guard`
+/// witness proves the [`RotationGuard`] is held, which makes the disk read
+/// stable. A cross-process peer (the daemon, a second clauth) rotates and
+/// persists under this same flock, and a caller that loaded config from disk
+/// once (CLI, MCP) can hold a snapshot predating that write. Tokens are opaque
+/// and no writer rewinds the store (see the scheduler's `fresher_disk_pair`),
+/// so a stored refresh token that DIFFERS from the in-memory one proves
+/// someone advanced the single-use chain: adopt the disk pair, and lift a
+/// stale quarantine — the chain is alive under someone else's advance
+/// (mirrors `carry_external_rotation`; a wrong lift self-corrects when the
+/// carried pair's own refresh 400s). Unreadable or tokenless disk state is a
+/// no-op: the in-memory shape stays the best available truth.
+fn adopt_disk_rotation(config: &crate::profile::ConfigHandle, name: &str, _guard: &RotationGuard) {
+    let Ok(disk) = crate::profile::load_profile(name) else {
+        return;
+    };
+    if disk.refresh_token().is_none() {
+        return;
+    }
+    {
+        let Ok(mut cfg) = config.lock() else {
+            return;
+        };
+        let Some(profile) = cfg.find_mut(name) else {
+            return;
+        };
+        if profile.refresh_token() == disk.refresh_token() {
+            return;
+        }
+        profile.credentials = disk.credentials;
+    }
+    mark_auth_broken(config, name, false);
+}
+
+/// The refresh leg; the `guard` witness proves the [`RotationGuard`] is held.
+/// First adopts a cross-process rotation from disk ([`adopt_disk_rotation`]),
+/// then re-reads the auth shape UNDER the guard — between the pre-check and
+/// guard acquisition a sibling rotation (in-process or peer) may have spent
+/// the single-use refresh token and persisted a new pair, and refreshing from
+/// that stale snapshot would 400 and wrongly quarantine a healthy login. This
+/// function takes no token arguments, so post-guard decisions structurally
+/// cannot reuse pre-guard data.
 fn gate_under_guard(
     config: &crate::profile::ConfigHandle,
     name: &str,
     refresher: impl Fn(&str) -> std::result::Result<TokenResponse, RefreshError>,
+    guard: &RotationGuard,
 ) -> AuthGate {
+    adopt_disk_rotation(config, name, guard);
     let (expires_at, refresh_token, flagged) = match oauth_shape(config, name) {
         Err(gate) => return gate,
         Ok(shape) => shape,

--- a/tests/inline/oauth.rs
+++ b/tests/inline/oauth.rs
@@ -930,3 +930,59 @@ mod adopt_live_rotation {
         );
     }
 }
+
+// ── post-guard re-read (the pre-RotationGuard token-snapshot race) ────────────
+//
+// Between the guard-less pre-check and RotationGuard acquisition a sibling
+// rotation can spend the single-use refresh token and persist a new pair;
+// refreshing from a pre-guard snapshot would 400 and wrongly quarantine a
+// healthy login. `gate_under_guard` therefore takes NO token arguments — its
+// decisions can only come from state read under the guard. These pin that
+// boundary directly.
+
+/// Stored pair already fresh when the guard leg runs (the sibling-refreshed
+/// interleave) → Ready, and the old chain is NOT double-spent (the refresher
+/// panics if called).
+#[test]
+fn gate_under_guard_installs_a_sibling_refreshed_pair_as_is() {
+    let _home = HomeSandbox::new();
+    let name = "test-gate-sibling-refreshed";
+    let handle = Arc::new(RankedMutex::new(oauth_config(
+        name,
+        Some("rt-fresh"),
+        Some(future_expiry()),
+    )));
+    assert!(matches!(
+        gate_under_guard(&handle, name, never_refresh),
+        AuthGate::Ready
+    ));
+}
+
+/// Still expiring under the guard → the refresher is fed the CURRENTLY stored
+/// refresh token, never a caller-supplied snapshot.
+#[test]
+fn gate_under_guard_spends_the_currently_stored_refresh_token() {
+    let _home = HomeSandbox::new();
+    let name = "test-gate-current-rt";
+    let handle = Arc::new(RankedMutex::new(oauth_config(
+        name,
+        Some("rt-current"),
+        Some(past_expiry()),
+    )));
+    let refresher = |rt: &str| {
+        assert_eq!(
+            rt, "rt-current",
+            "must spend the token read under the guard"
+        );
+        Ok(TokenResponse {
+            access_token: "at-new".to_string(),
+            refresh_token: "rt-next".to_string(),
+            expires_in: 3600,
+            scope: None,
+        })
+    };
+    assert!(matches!(
+        gate_under_guard(&handle, name, refresher),
+        AuthGate::Refreshed
+    ));
+}

--- a/tests/inline/oauth.rs
+++ b/tests/inline/oauth.rs
@@ -940,6 +940,28 @@ mod adopt_live_rotation {
 // decisions can only come from state read under the guard. These pin that
 // boundary directly.
 
+/// The rotation lock the guard leg demands proof of (production callers hold
+/// it across the whole refresh window).
+fn gate_guard(name: &str) -> crate::runtime::RotationGuard {
+    crate::runtime::RotationGuard::acquire(name).expect("rotation guard")
+}
+
+/// Persist a peer's rotation to the on-disk profile store — the state a
+/// cross-process rotation leaves behind for `adopt_disk_rotation` to find.
+fn save_disk_profile(name: &str, refresh: &str, expires_at: Option<i64>) {
+    let mut p = Profile::new(name.to_string(), None, None);
+    p.credentials = Some(ClaudeCredentials {
+        claude_ai_oauth: Some(OAuthToken {
+            access_token: "at-disk".to_string(),
+            refresh_token: Some(refresh.to_string()),
+            expires_at,
+            scopes: None,
+            subscription_type: None,
+        }),
+    });
+    crate::profile::save_profile(&p).expect("save disk profile");
+}
+
 /// Stored pair already fresh when the guard leg runs (the sibling-refreshed
 /// interleave) → Ready, and the old chain is NOT double-spent (the refresher
 /// panics if called).
@@ -953,7 +975,7 @@ fn gate_under_guard_installs_a_sibling_refreshed_pair_as_is() {
         Some(future_expiry()),
     )));
     assert!(matches!(
-        gate_under_guard(&handle, name, never_refresh),
+        gate_under_guard(&handle, name, never_refresh, &gate_guard(name)),
         AuthGate::Ready
     ));
 }
@@ -982,7 +1004,86 @@ fn gate_under_guard_spends_the_currently_stored_refresh_token() {
         })
     };
     assert!(matches!(
-        gate_under_guard(&handle, name, refresher),
+        gate_under_guard(&handle, name, refresher, &gate_guard(name)),
         AuthGate::Refreshed
     ));
+}
+
+/// A cross-process peer rotated and persisted while this process held a stale
+/// in-memory config snapshot (the CLI and MCP load config from disk once and
+/// never reload): under the guard the DISK pair is authoritative. A live disk
+/// pair installs as-is — the stale in-memory token is never spent (the
+/// refresher panics if called) — and the handle carries the adopted pair.
+#[test]
+fn gate_under_guard_adopts_a_cross_process_rotation_from_disk() {
+    let _home = HomeSandbox::new();
+    let name = "test-gate-disk-adopt";
+    let handle = Arc::new(RankedMutex::new(oauth_config(
+        name,
+        Some("rt-stale"),
+        Some(past_expiry()),
+    )));
+    save_disk_profile(name, "rt-peer", Some(future_expiry()));
+    assert!(matches!(
+        gate_under_guard(&handle, name, never_refresh, &gate_guard(name)),
+        AuthGate::Ready
+    ));
+    assert_eq!(
+        handle.lock().unwrap().find(name).unwrap().refresh_token(),
+        Some("rt-peer"),
+        "the adopted disk pair must replace the stale in-memory snapshot"
+    );
+}
+
+/// Peer-rotated pair that is ITSELF already expiring again: the refresher must
+/// be fed the disk refresh token — spending the stale in-memory one would 400
+/// (already spent by the peer) and wrongly quarantine a healthy login.
+#[test]
+fn gate_under_guard_spends_the_disk_pair_after_an_external_rotation() {
+    let _home = HomeSandbox::new();
+    let name = "test-gate-disk-spend";
+    let handle = Arc::new(RankedMutex::new(oauth_config(
+        name,
+        Some("rt-stale"),
+        Some(past_expiry()),
+    )));
+    save_disk_profile(name, "rt-peer", Some(past_expiry()));
+    let refresher = |rt: &str| {
+        assert_eq!(rt, "rt-peer", "must spend the disk pair, not the snapshot");
+        Ok(TokenResponse {
+            access_token: "at-new".to_string(),
+            refresh_token: "rt-next".to_string(),
+            expires_in: 3600,
+            scope: None,
+        })
+    };
+    assert!(matches!(
+        gate_under_guard(&handle, name, refresher, &gate_guard(name)),
+        AuthGate::Refreshed
+    ));
+}
+
+/// A differing disk pair proves the chain is alive, so a standing in-memory
+/// quarantine is stale and lifts (same rationale as the scheduler's
+/// `carry_external_rotation`): the gate proceeds from the adopted pair
+/// instead of refusing a recovered login.
+#[test]
+fn gate_under_guard_disk_adoption_lifts_a_stale_quarantine() {
+    let _home = HomeSandbox::new();
+    let name = "test-gate-disk-quarantine";
+    let handle = Arc::new(RankedMutex::new(oauth_config(
+        name,
+        Some("rt-stale"),
+        Some(future_expiry()),
+    )));
+    handle.lock().unwrap().set_auth_broken(name, true);
+    save_disk_profile(name, "rt-peer", Some(future_expiry()));
+    assert!(matches!(
+        gate_under_guard(&handle, name, never_refresh, &gate_guard(name)),
+        AuthGate::Ready
+    ));
+    assert!(
+        !handle.lock().unwrap().is_auth_broken(name),
+        "an adopted (alive) chain lifts a stale quarantine"
+    );
 }


### PR DESCRIPTION
Follow-up to #25 — this is the "pre-`RotationGuard` token-snapshot race in the `ensure_installable` gate" you flagged in the #27 review.

## The race

`ensure_installable` snapshots `(expires_at, refresh_token, flagged)` under the config lock, releases it, and only **then** acquires the `RotationGuard`. In that window a sibling rotation (a live session's chain advance, the scheduler's `rotate_one`, another switch path) can spend the single-use refresh token and persist a new pair. The gate then feeds the **stale snapshot** to the refresher:

- the spend 400s as `Invalid` → `mark_auth_broken(name, true)` — a healthy login with a perfectly fresh pair on disk gets **wrongly quarantined**, and
- depending on server-side rotation policy, spending an already-consumed token can burn the chain that just got minted.

## The fix

The refresh leg is split into `gate_under_guard`, entered only with the guard held, and it **takes no token arguments** — post-guard decisions structurally cannot reuse pre-guard data:

- it re-reads `(expires_at, refresh_token, flagged)` under the guard (authoritative: the guard serializes rotations, so nothing can invalidate this read),
- a sibling-refreshed pair (no longer expiring, flag lifted) returns `Ready` and installs as-is instead of double-spending the old chain,
- still-expiring state refreshes from the **currently stored** token.

The guard-less pre-check stays as the cheap early-exit for non-OAuth / comfortably-live tokens; its token data is discarded. The `auth_broken`-overrides-the-clock semantics from the quarantine work are preserved verbatim in both legs (shared `expiring(expires_at, flagged)` helper).

## Tests

Two new tests pin the boundary directly on `gate_under_guard` (the function boundary is what makes the race unrepresentable, so the tests target it):
- `gate_under_guard_installs_a_sibling_refreshed_pair_as_is` — fresh stored pair → `Ready`, refresher (a panic fixture) never runs;
- `gate_under_guard_spends_the_currently_stored_refresh_token` — still expiring → the refresher receives the token read under the guard.

All 7 existing `gate_*` tests unchanged and green (including `gate_flagged_profile_refreshes_despite_a_valid_clock`). 705 tests, clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)