### PR TITLE
feat(scheduler): distrust a deep-slot stuck RateLimited active (the #37 follow-up)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -418,6 +418,14 @@ impl Daemon {
             .lock()
             .map(|m| m.clone())
             .unwrap_or_default();
+        // Snapshot the 429 streaks so build_status can publish `stale` (a
+        // deep-slot stuck RateLimited). Lower rank than config, like the stores
+        // above — snapshot + release before the config lock.
+        let streaks_snap: HashMap<String, u32> = self
+            .rate_limit_streaks
+            .lock()
+            .map(|m| m.clone())
+            .unwrap_or_default();
         // The in-flight switch target (accepted, not yet applied), so the UI
         // shows in-flight truth instead of a timing heuristic. Snapshot + release
         // before the config lock, like the freshness stores above. The set holds
@@ -431,6 +439,7 @@ impl Daemon {
         let live = LiveSignals {
             status: &status_snap,
             next_refresh: &next_snap,
+            streaks: &streaks_snap,
             pending_switch: pending_snap.as_deref(),
         };
         let body = {

--- a/src/daemon/status_json.rs
+++ b/src/daemon/status_json.rs
@@ -18,7 +18,7 @@ use crate::profile_cache::{
 };
 use crate::profile_json::{provider_label, tier_label, windows_json};
 use crate::providers::ThirdPartyStats;
-use crate::usage::{FetchStatus, epoch_secs_to_iso, now_ms};
+use crate::usage::{FetchStatus, epoch_secs_to_iso, is_stuck_rate_limited, now_ms};
 
 /// Bump when the JSON shape changes in a way readers must branch on.
 pub(crate) const SCHEMA_VERSION: u64 = 1;
@@ -35,6 +35,12 @@ pub(crate) const SCHEMA_VERSION: u64 = 1;
 pub(crate) struct LiveSignals<'a> {
     pub(crate) status: &'a HashMap<String, FetchStatus>,
     pub(crate) next_refresh: &'a HashMap<String, u64>,
+    /// Consecutive-429 streaks, so a profile whose live `status` is `RateLimited`
+    /// AND whose streak has passed the active cap can be published as `stale` (a
+    /// deep-slot stuck read the daemon distrusts — the same judgment
+    /// `scan_auto_switch` acts on). Empty for the single-shot `status --json` (no
+    /// daemon), so `stale` is always `false` there.
+    pub(crate) streaks: &'a HashMap<String, u32>,
     /// The switch target the daemon has accepted but not yet applied (from
     /// `pending_switch`), so a reader can show in-flight truth instead of a
     /// timing heuristic. `None` for the single-shot `status --json` (no daemon).
@@ -144,6 +150,20 @@ pub(crate) fn build_status(
                 None => derived_next(),
             };
 
+            // `stale` = the daemon distrusts this reading — a deep-slot stuck
+            // RateLimited (live status RateLimited AND the 429 streak past the
+            // active cap). Read from the LIVE store, not the mtime-derived
+            // fetch_status string (which never yields RateLimited), so it is only
+            // ever true under a real daemon. The single-shot has no streaks →
+            // always false. Same predicate `scan_auto_switch` distrusts, so the
+            // published flag and the switch decision cannot drift.
+            let stale = match live {
+                Some(sig) => sig.status.get(name).copied().is_some_and(|s| {
+                    is_stuck_rate_limited(s, sig.streaks.get(name).copied().unwrap_or(0))
+                }),
+                None => false,
+            };
+
             // Structured third-party balance isn't carried by ThirdPartyStats
             // (it lives in free-text `rows`); expose only the availability flag
             // for now — enough for a reader's red/green reachability dot.
@@ -163,6 +183,11 @@ pub(crate) fn build_status(
                 "has_live_session": crate::runtime::has_live_session(name),
                 "auth_status": auth_status_str(config, p, now as i64),
                 "fetch_status": fetch_status,
+                // Additive (schema stays 1): true when the daemon distrusts this
+                // reading as a deep-slot stuck RateLimited — readers dim it / show
+                // a "stuck" cue instead of treating it as current truth. Always
+                // false for the single-shot `status --json`.
+                "stale": stale,
                 "fetched_at": mtime_ms.map(iso_from_ms),
                 "next_refresh_at": next_refresh_ms.map(iso_from_ms),
                 "auto_start": p.auto_start,

--- a/src/usage/mod.rs
+++ b/src/usage/mod.rs
@@ -20,6 +20,12 @@ pub(crate) use scheduler::{
     RefetchQueue, StartupReceiver, StartupSender, StartupSignal, StatusStore,
     SuppressedGenericStore, ThirdPartyList, ThirdPartyStatusStore, ThirdPartyUsageStore, TokenList,
     UsageStore, any_busy, bootstrap_fetch, bootstrap_third_party, clear_activity,
-    collect_third_party_entries, collect_tokens, is_idle, mark_activity, spawn_refresher,
-    switch_gate_in_flight,
+    collect_third_party_entries, collect_tokens, is_idle, is_stuck_rate_limited, mark_activity,
+    spawn_refresher, switch_gate_in_flight,
 };
+// The active-cap boundary is only referenced by tests (production code reaches it
+// through `is_stuck_rate_limited`); gate the re-export behind `cfg(test)` so it
+// isn't a dead symbol in the shipped binary, while keeping the `stale`/distrust
+// tests robust against a change to the constant's value.
+#[cfg(test)]
+pub(crate) use scheduler::ACTIVE_CAP_MAX_STREAK;

--- a/src/usage/scheduler.rs
+++ b/src/usage/scheduler.rs
@@ -54,7 +54,7 @@ const RATE_LIMIT_BACKOFF_FACTOR: u64 = 3;
 /// long as a genuine storm lasts. At the default 90s cadence this bound buys
 /// ~6 dense probes (≈3 min apart) over the storm's first quarter hour — enough
 /// to re-discover a recovered endpoint fast — before conceding to the ladder.
-const ACTIVE_CAP_MAX_STREAK: u32 = 6;
+pub(crate) const ACTIVE_CAP_MAX_STREAK: u32 = 6;
 
 /// Wall-clock instant in epoch-milliseconds. Distinct from [`IntervalMs`] so
 /// instants and spans can't be confused. `#[repr(transparent)]` keeps layout
@@ -1628,6 +1628,7 @@ fn tick(state: &SchedulerState) {
         &state.config,
         &state.store,
         &state.status,
+        &state.rate_limit_streaks,
         &state.activity,
         &state.pending_switch,
         &state.pending_switch_off,
@@ -1824,10 +1825,31 @@ fn decision_fresh(status: &StatusStore, name: &str) -> bool {
     )
 }
 
+/// True when `name`'s last reading is a **deep-slot stuck** `RateLimited`: the
+/// status is `RateLimited` AND its consecutive-429 streak has passed
+/// [`ACTIVE_CAP_MAX_STREAK`] — the boundary where the active cap stops holding
+/// retries frequent. Past it, a still-`RateLimited` read is genuinely stuck (the
+/// `/usage` throttle window never drained), not a transient blip.
+///
+/// ONE predicate, two consumers, so display and decision cannot drift:
+///   * `scan_auto_switch` distrusts a stuck-RateLimited active — it bypasses the
+///     [`decision_fresh`] gate exactly like an auth-broken active (AUTH-4) so the
+///     walk can rotate away instead of wedging on an account that can never
+///     return `Fresh`. The switch still requires the walk's own last-known
+///     exhaustion gate ([`crate::fallback::next_auto_switch_target`]), so a
+///     throttle artifact with real headroom stays put — only a genuinely spent
+///     stuck active moves.
+///   * `status.json`'s per-profile `stale` flag publishes the same judgment so a
+///     menu-bar reader renders the reading as distrusted, not current truth.
+pub(crate) fn is_stuck_rate_limited(status: FetchStatus, streak: u32) -> bool {
+    matches!(status, FetchStatus::RateLimited) && streak > ACTIVE_CAP_MAX_STREAK
+}
+
 fn scan_auto_switch(
     config: &crate::profile::ConfigHandle,
     store: &UsageStore,
     status: &StatusStore,
+    streaks: &RateLimitStreaks,
     _activity: &ActivityStore,
     pending_switch: &PendingSwitch,
     pending_switch_off: &PendingSwitchOff,
@@ -1863,12 +1885,23 @@ fn scan_auto_switch(
 
     // Only act on a confirmed-live read of the active profile — a stale or
     // synthetic store entry would drive a false switch (see `decision_fresh`).
-    // EXCEPT an auth-broken active (AUTH-4): its fetches can never come back
-    // Fresh again (the login is dead), so requiring one froze this scan
-    // forever and wedged the daemon on the dead account (observed
-    // 2026-07-09); the walk never consults the broken active's own usage.
+    // TWO exceptions bypass the freshness gate, both because the active can
+    // never come back Fresh on its own so requiring one wedges the scan on it:
+    //   * an auth-broken active (AUTH-4) — its login is dead (observed
+    //     2026-07-09); the walk never consults its usage.
+    //   * a deep-slot stuck RateLimited active (the RateLimited analogue) — the
+    //     `/usage` throttle stayed pinned past the active cap, so no Fresh read
+    //     is coming. Unlike auth-broken, this one still faces the walk's
+    //     last-known exhaustion gate, so a throttle artifact with headroom stays
+    //     put and only a genuinely spent stuck active rotates away.
     let active_broken = snapshot.broken.iter().any(|b| b == &snapshot.active);
-    if !active_broken && !decision_fresh(status, &snapshot.active) {
+    let active_status = status
+        .lock()
+        .ok()
+        .and_then(|m| m.get(&snapshot.active).copied());
+    let active_stuck_rl = active_status
+        .is_some_and(|s| is_stuck_rate_limited(s, rate_limit_streak(streaks, &snapshot.active)));
+    if !active_broken && !active_stuck_rl && !matches!(active_status, Some(FetchStatus::Fresh)) {
         return;
     }
 

--- a/tests/inline/daemon_status_json.rs
+++ b/tests/inline/daemon_status_json.rs
@@ -78,6 +78,7 @@ fn build_status_top_level_shape_and_active() {
             "name",
             "next_refresh_at",
             "provider",
+            "stale",
             "third_party",
             "tier",
             "windows",
@@ -182,6 +183,7 @@ fn build_status_pending_switch_reflects_live_signal() {
     };
     let empty_status = std::collections::HashMap::new();
     let empty_next = std::collections::HashMap::new();
+    let empty_streaks = std::collections::HashMap::new();
 
     // single-shot (no daemon) → pending_switch is present-but-null.
     let none = build_status(&config, 300_000, None);
@@ -194,6 +196,7 @@ fn build_status_pending_switch_reflects_live_signal() {
     let live = LiveSignals {
         status: &empty_status,
         next_refresh: &empty_next,
+        streaks: &empty_streaks,
         pending_switch: Some("home"),
     };
     let v = build_status(&config, 300_000, Some(&live));
@@ -248,9 +251,11 @@ fn build_status_third_party_freshness_from_its_own_cache() {
     // never do for api-key profiles): same derivation, not null.
     let empty_status = std::collections::HashMap::new();
     let empty_next = std::collections::HashMap::new();
+    let empty_streaks = std::collections::HashMap::new();
     let live = LiveSignals {
         status: &empty_status,
         next_refresh: &empty_next,
+        streaks: &empty_streaks,
         pending_switch: None,
     };
     let v = build_status(&config, 300_000, Some(&live));
@@ -260,4 +265,91 @@ fn build_status_third_party_freshness_from_its_own_cache() {
         "a live daemon must not blank an api-key profile's freshness"
     );
     assert!(!p["next_refresh_at"].is_null());
+}
+
+// RLS-1: the additive per-profile `stale` flag = the daemon distrusts this
+// reading as a deep-slot stuck RateLimited (live status RateLimited AND the 429
+// streak past the active cap) — the SAME predicate `scan_auto_switch` acts on,
+// so the published cue and the switch decision cannot drift. Additive: schema
+// stays 1; the single-shot (no streaks) is always false.
+#[test]
+fn build_status_stale_flags_a_deep_slot_stuck_rate_limited_profile() {
+    use crate::usage::FetchStatus;
+    use std::collections::HashMap;
+
+    let _home = HomeSandbox::new();
+    // TWO profiles, so a "computed once and applied to every row" regression
+    // (rather than keyed per profile name) is catchable.
+    let config = AppConfig {
+        state: AppState::default(),
+        profiles: vec![oauth_profile("work"), oauth_profile("home")],
+    };
+    let next: HashMap<String, u64> = HashMap::new();
+    let deep = crate::usage::ACTIVE_CAP_MAX_STREAK + 1;
+    let stale_of = |name: &str, v: &serde_json::Value| -> serde_json::Value {
+        v["profiles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["name"] == name)
+            .unwrap()["stale"]
+            .clone()
+    };
+
+    // single-shot (no daemon / no streaks) → stale is present-and-false.
+    let none = build_status(&config, 300_000, None);
+    assert_eq!(
+        none["schema"], 1,
+        "stale is additive — schema must not bump"
+    );
+    assert_eq!(
+        stale_of("work", &none),
+        false,
+        "single-shot never publishes a distrusted reading"
+    );
+
+    // Two profiles in ONE body: `work` is a deep-slot stuck RateLimited (→ stale),
+    // `home` is Fresh with an (irrelevant) equally-deep streak (→ NOT stale). This
+    // one call proves the flag keys on the profile's OWN status+streak, is
+    // per-profile (not one value smeared across the array), and that streak depth
+    // alone never stales a live reading.
+    let status = HashMap::from([
+        ("work".to_string(), FetchStatus::RateLimited),
+        ("home".to_string(), FetchStatus::Fresh),
+    ]);
+    let streaks = HashMap::from([("work".to_string(), deep), ("home".to_string(), deep)]);
+    let live = LiveSignals {
+        status: &status,
+        next_refresh: &next,
+        streaks: &streaks,
+        pending_switch: None,
+    };
+    let v = build_status(&config, 300_000, Some(&live));
+    assert_eq!(
+        stale_of("work", &v),
+        true,
+        "a deep-slot stuck RateLimited reading is published as stale"
+    );
+    assert_eq!(
+        stale_of("home", &v),
+        false,
+        "a Fresh sibling is never stale however deep its streak — and stale is \
+         per-profile, not computed once and applied to the whole array"
+    );
+
+    // Shallow RateLimited (≤ cap) → not yet distrusted.
+    let status = HashMap::from([("work".to_string(), FetchStatus::RateLimited)]);
+    let streaks = HashMap::from([("work".to_string(), crate::usage::ACTIVE_CAP_MAX_STREAK)]);
+    let live = LiveSignals {
+        status: &status,
+        next_refresh: &next,
+        streaks: &streaks,
+        pending_switch: None,
+    };
+    let v = build_status(&config, 300_000, Some(&live));
+    assert_eq!(
+        stale_of("work", &v),
+        false,
+        "a shallow RateLimited reading is not stale"
+    );
 }

--- a/tests/inline/scheduler.rs
+++ b/tests/inline/scheduler.rs
@@ -670,10 +670,11 @@ fn scan_auto_switch_walks_off_a_broken_active_without_a_fresh_read() {
             ("a".to_string(), FetchStatus::RateLimited),
             ("b".to_string(), FetchStatus::Fresh),
         ])));
+        let streaks: super::RateLimitStreaks = Arc::new(RankedMutex::new(HashMap::new()));
         let activity: ActivityStore = Arc::new(RankedMutex::new(HashMap::new()));
         let pending: PendingSwitch = Arc::new(RankedMutex::new(HashSet::new()));
         let pending_off: PendingSwitchOff = Arc::new(RankedMutex::new(false));
-        (store, status, activity, pending, pending_off)
+        (store, status, streaks, activity, pending, pending_off)
     };
     let config_handle = |broken: bool| -> crate::profile::ConfigHandle {
         let mut cfg = AppConfig {
@@ -693,11 +694,12 @@ fn scan_auto_switch_walks_off_a_broken_active_without_a_fresh_read() {
     };
 
     // Broken active → the gate is bypassed and the walk queues the sibling.
-    let (store, status, activity, pending, pending_off) = frozen_state();
+    let (store, status, streaks, activity, pending, pending_off) = frozen_state();
     scan_auto_switch(
         &config_handle(true),
         &store,
         &status,
+        &streaks,
         &activity,
         &pending,
         &pending_off,
@@ -707,12 +709,14 @@ fn scan_auto_switch_walks_off_a_broken_active_without_a_fresh_read() {
         "a dead active must be walked away from without waiting for a Fresh read"
     );
 
-    // Healthy active, identical frozen stores → the freshness gate holds.
-    let (store, status, activity, pending, pending_off) = frozen_state();
+    // Healthy active, identical frozen stores (lapsed window = headroom, shallow
+    // streak) → the freshness gate holds: not broken, not stuck-RL, not Fresh.
+    let (store, status, streaks, activity, pending, pending_off) = frozen_state();
     scan_auto_switch(
         &config_handle(false),
         &store,
         &status,
+        &streaks,
         &activity,
         &pending,
         &pending_off,
@@ -720,6 +724,130 @@ fn scan_auto_switch_walks_off_a_broken_active_without_a_fresh_read() {
     assert!(
         pending.lock().unwrap().is_empty(),
         "a merely-stale healthy active must still not drive a switch"
+    );
+}
+
+/// RLS-1 (the RateLimited analogue of AUTH-4): a **deep-slot stuck RateLimited**
+/// active bypasses the freshness gate so the daemon stops wedging on a
+/// rate-limited account — but, unlike auth-broken, the switch still faces the
+/// walk's last-known exhaustion gate. Four cases share one frozen shape:
+///   * deep streak (> cap) + genuinely-spent LIVE window → switches away;
+///   * deep streak + LIVE headroom → stays (throttle artifact, no false switch);
+///   * deep streak + stale-HIGH but LAPSED window → stays — the load-bearing
+///     RLS-1↔AUTH-4 asymmetry: this is the exact frozen shape a real 429 storm
+///     holds (the last Fresh window is preserved; after ~5h it lapses to
+///     `resets_at` in the past). An auth-broken active WALKS AWAY on this same
+///     store (it bypasses the exhaustion gate too); a stuck-RL active must NOT,
+///     since `five_hour_live` reads the lapsed window as regained headroom. A
+///     false switch here would log out every running claude over a reset account;
+///   * shallow streak (≤ cap) + spent window → stays (give the active cap's
+///     frequent retries a chance to return a Fresh read first).
+#[test]
+fn scan_auto_switch_distrusts_a_deep_slot_stuck_rate_limited_active() {
+    use super::{
+        ACTIVE_CAP_MAX_STREAK, FetchStatus, PendingSwitch, PendingSwitchOff, RateLimitStreaks,
+        StatusStore, scan_auto_switch,
+    };
+    use crate::profile::{AppConfig, AppState, Profile};
+    use crate::usage::{UsageInfo, UsageStore, UsageWindow, epoch_secs_to_iso, now_epoch_secs};
+
+    // `a` is active and RateLimited; `active_util` on a 5h window whose reset is
+    // `resets_offset` seconds from now (negative = a LAPSED window, which
+    // `five_hour_live` reads as regained headroom regardless of `active_util`);
+    // `streak` sets slot depth. `b` is a viable Fresh sibling.
+    let frozen_state = |active_util: f64, resets_offset: i64, streak: u32| {
+        let store: UsageStore = Arc::new(RankedMutex::new(HashMap::from([
+            (
+                "a".to_string(),
+                UsageInfo {
+                    five_hour: Some(UsageWindow {
+                        utilization: active_util,
+                        resets_at: Some(epoch_secs_to_iso(now_epoch_secs() + resets_offset)),
+                    }),
+                    ..Default::default()
+                },
+            ),
+            (
+                "b".to_string(),
+                UsageInfo {
+                    five_hour: Some(UsageWindow {
+                        utilization: 10.0,
+                        resets_at: Some(epoch_secs_to_iso(now_epoch_secs() + 3600)),
+                    }),
+                    ..Default::default()
+                },
+            ),
+        ])));
+        let status: StatusStore = Arc::new(RankedMutex::new(HashMap::from([
+            ("a".to_string(), FetchStatus::RateLimited),
+            ("b".to_string(), FetchStatus::Fresh),
+        ])));
+        let streaks: RateLimitStreaks =
+            Arc::new(RankedMutex::new(HashMap::from([("a".to_string(), streak)])));
+        let activity: ActivityStore = Arc::new(RankedMutex::new(HashMap::new()));
+        let pending: PendingSwitch = Arc::new(RankedMutex::new(HashSet::new()));
+        let pending_off: PendingSwitchOff = Arc::new(RankedMutex::new(false));
+        (store, status, streaks, activity, pending, pending_off)
+    };
+    let config_handle = || -> crate::profile::ConfigHandle {
+        Arc::new(RankedMutex::new(AppConfig {
+            state: AppState {
+                active_profile: Some("a".into()),
+                profiles: vec!["a".into(), "b".into()],
+                fallback_chain: vec!["a".into(), "b".into()],
+                ..AppState::default()
+            },
+            profiles: vec![
+                Profile::new("a".to_string(), None, None),
+                Profile::new("b".to_string(), None, None),
+            ],
+        }))
+    };
+    let deep = ACTIVE_CAP_MAX_STREAK + 1;
+    // The set of profiles the scan queued a switch to (sorted for determinism).
+    let run = |util: f64, resets_offset: i64, streak: u32| -> Vec<String> {
+        let (store, status, streaks, activity, pending, pending_off) =
+            frozen_state(util, resets_offset, streak);
+        scan_auto_switch(
+            &config_handle(),
+            &store,
+            &status,
+            &streaks,
+            &activity,
+            &pending,
+            &pending_off,
+        );
+        let mut queued: Vec<String> = pending.lock().unwrap().iter().cloned().collect();
+        queued.sort();
+        queued
+    };
+
+    // Deep slot + genuinely spent (LIVE window ≥ threshold) → the wedge breaks.
+    assert_eq!(
+        run(100.0, 3600, deep),
+        vec!["b".to_string()],
+        "a deep-slot stuck RateLimited active that is genuinely spent must be walked away from"
+    );
+    // Deep slot but real LIVE headroom → no false switch (the walk's exhaustion
+    // gate still holds; distrusting the STATUS never means trusting spent NUMBERS).
+    assert!(
+        run(10.0, 3600, deep).is_empty(),
+        "a stuck RateLimited active with last-known headroom must stay put"
+    );
+    // Deep slot + stale-HIGH but LAPSED window (the real post-storm shape) → STAY.
+    // This is where RLS-1 diverges from AUTH-4: a broken active walks away on this
+    // identical store, a stuck-RL one must not — `five_hour_live` reads the lapsed
+    // window as regained headroom, so the account is NOT exhausted.
+    assert!(
+        run(100.0, -3600, deep).is_empty(),
+        "a stuck RateLimited active whose maxed window has since LAPSED must stay put \
+         (regained headroom), never false-switch off a reset account"
+    );
+    // Shallow slot + spent → still gated on Fresh; the active cap's frequent
+    // retries get a chance to return a live read before we distrust.
+    assert!(
+        run(100.0, 3600, ACTIVE_CAP_MAX_STREAK).is_empty(),
+        "a shallow RateLimited active must still wait for a Fresh read"
     );
 }
 

--- a/wiki/daemon.md
+++ b/wiki/daemon.md
@@ -60,6 +60,7 @@ key** — names, tiers, percentages, timestamps only.
       "has_live_session": true,
       "auth_status": "ok",
       "fetch_status": "Fresh",
+      "stale": false,
       "fetched_at": "2026-07-03T19:04:20+00:00",
       "next_refresh_at": "2026-07-03T19:09:20+00:00",
       "auto_start": true,
@@ -89,6 +90,7 @@ key** — names, tiers, percentages, timestamps only.
 | `profiles[].tier` | Plan label (`"Max 5x"`…), `null` when unknown. Opaque display string. |
 | `profiles[].auth_status` | `"ok" \| "expiring" \| "broken"`. `broken` = last refresh rejected as revoked/invalid → excluded from fallback walks, refused as a switch target. `expiring` = past expiry, not yet refreshed. `broken` outranks `expiring`. Absent ⇒ `"ok"`. |
 | `profiles[].fetch_status` | `"Fresh" \| "Cached" \| "Failed" \| "RateLimited"` — the usage fetch's last outcome, so readers can distinguish live bars from last-known. `Failed`/`RateLimited` come only from a live daemon's OAuth fetch leg; api-key profiles (and any name the live stores don't carry yet) derive `Fresh`/`Cached` from their own cache's mtime instead — an api-key profile with a warm cache is never reported as unfetched. `null` = no cache at all (genuinely never fetched). |
+| `profiles[].stale` | `bool` (additive, schema stays 1; absent ⇒ `false`). `true` when the daemon distrusts this reading as a **deep-slot stuck `RateLimited`**: `fetch_status == "RateLimited"` AND the consecutive-429 streak has passed the active-retry cap, so the `/usage` throttle never drained and no `Fresh` read is coming. This is the same judgment the daemon's auto-switch acts on — a stuck-RateLimited active bypasses the "only act on a Fresh read" gate so the chain rotates away instead of wedging (the `RateLimited` analogue of the `auth_status: "broken"` bypass); the switch still requires the active's last-known usage to be genuinely spent, so a throttle blip with headroom stays put. Readers should dim the meter / show a "stuck" cue rather than render the frozen number as current truth. `false` for a shallow/transient `RateLimited`, for every non-`RateLimited` status, and **always** for the single-shot `clauth status --json` (no daemon, no streak history). |
 | `profiles[].fallback` | `null` when not in the chain; else 1-based `position`, `threshold` (%), `armed` (this member is the active one the auto-switch watches). |
 | `profiles[].windows[]` | `label` is **derived, not an enum**: `"5h"` and `"7d"` always; the third is a plan-tier label (`"7d Opus"`…). Treat labels as opaque display strings, never keys to switch on. `utilization_pct` 0–100 float; `resets_at` nullable. |
 | `profiles[].third_party` | `{ "available": bool }` for api-key profiles once probed, else `null` — including an api-key profile whose provider has never been reached (no cache yet). Plain reachability; structured balances deliberately deferred. |


### PR DESCRIPTION
Taking you up on the principled follow-up you offered when merging #37:

> keep the poll cadence untouched, mark a deep-slot active `RateLimited` as stale in the TUI + have `scan_auto_switch` distrust it. Kills the stated harm with zero extra `/usage` load.

This is the consumer-side complement to #37's poll-side cap.

## The wedge

`scan_auto_switch` only trusts a `Fresh` active read to decide a switch (via `decision_fresh`). A stuck-`RateLimited` active — one whose `/usage` polls stay 429'd past the active cap and can therefore never return `Fresh` — makes the scan bail every tick, so the daemon **wedges on the rate-limited account and never rotates away**. It's the `RateLimited` analogue of the auth-broken wedge that already has an `active_broken` bypass.

## The fix — two parts, mirroring the auth-broken bypass

1. **Decision.** New `is_stuck_rate_limited(status, streak)` = `RateLimited && streak > ACTIVE_CAP_MAX_STREAK` (reusing #37's own cap boundary as the deep-slot line — within the cap window retries are kept frequent, so only *past* it is a still-`RateLimited` read genuinely stuck). `scan_auto_switch` gets a third bypass beside `active_broken`. Crucially the bypass only lets the walk **run** — unlike auth-broken it still faces `next_auto_switch_target`'s last-known exhaustion gate (guarded by `five_hour_live` + the weekly reset). So a genuinely-spent stuck active rotates away (wedge fixed) while a throttle artifact with real headroom **stays put** (no false switch). `fallback.rs` is untouched — that gate is the safety.

2. **Display.** The same predicate publishes an additive per-profile `status.json` `stale: bool` (schema stays 1; always `false` for the single-shot `status --json`), threaded via `LiveSignals.streaks`, so a menu-bar reader can dim a distrusted reading instead of rendering the frozen number as truth. One shared predicate → decision and display can't drift. Documented in `wiki/daemon.md`.

Zero extra `/usage` load — pure reinterpretation of data the scheduler already holds.

## Tests

`scan_auto_switch` walks off a deep-slot stuck-**spent** active; stays on a throttle artifact (LIVE headroom) **and** on a lapsed-stale-high window — the real post-storm shape, and the exact point this diverges from the auth-broken bypass, which *walks* on that same store; still waits for `Fresh` on a shallow streak. `build_status` `stale` is per-profile (proved with two profiles in one body), additive, and false for the single-shot. Full suite + `fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)