### PR TITLE
fix(daemon): don't defer switches behind Claude Code's logged-out shell

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -84,10 +84,8 @@ pub(crate) fn switch_profile(config: &mut AppConfig, name: &str) -> Result<()> {
         // switch. (Interactive callers already route a real divergence to the
         // reconcile path, so this branch is only reachable uncaptured via the
         // scheduler — where refusing, not dropping, is the safe outcome.)
-        // Claude Code's logged-out shell (both tokens blanked) is NOT an
-        // uncaptured re-login: there is no login in it to strand, and the
-        // non-force guard would otherwise refuse to replace the empty file,
-        // wedging every switch until a human resolves nothing in the TUI.
+        // A logged-out shell holds no login to strand, so it forfeits the
+        // refuse-guard (which would otherwise wedge the switch on an empty file).
         let uncaptured_relogin = match config.state.active_profile.as_deref() {
             Some(active) => {
                 matches!(classify_credentials_link(active)?, LinkState::Diverged)
@@ -140,10 +138,9 @@ pub(crate) fn switch_profile_cli(config: AppConfig, canonical: &str) -> Result<(
     let outgoing = config.state.active_profile.clone();
 
     // Diverged link = CC re-logged and wrote a regular file; must reconcile
-    // (capture into outgoing profile) rather than refuse. CC's logged-out
-    // shell (both tokens blanked) is exempt: capturing empty tokens over the
-    // outgoing profile's stored login would destroy it, so the shell takes the
-    // plain switch below and is replaced wholesale.
+    // (capture into outgoing profile) rather than refuse. A logged-out shell is
+    // exempt: capturing its blank tokens would destroy the outgoing profile's
+    // stored login.
     let reconciled = match outgoing.as_deref() {
         Some(active) => {
             matches!(classify_credentials_link(active)?, LinkState::Diverged)
@@ -278,9 +275,8 @@ pub(crate) fn switch_profile_noninteractive(
         }
     }
 
-    // CC's logged-out shell (both tokens blanked) is not a divergence to
-    // resolve: no divergence default is consulted and the plain switch below
-    // replaces the empty file (same exemption as the CLI path above).
+    // A logged-out shell is no divergence to resolve: skip the default and take
+    // the plain switch, which replaces the empty file.
     let diverged = match previous.as_deref() {
         Some(active) => {
             matches!(classify_credentials_link(active)?, LinkState::Diverged)

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -11,8 +11,8 @@ use anyhow::{Context, Result, bail};
 use crate::claude::{
     ClaudeEndpoint, LinkState, apply_profile_to_claude_settings, classify_credentials_link,
     clear_claude_credentials, force_link_profile_credentials, force_snapshot_active_credentials,
-    is_first_login, link_profile_credentials, managed_env_key_label, read_claude_credentials,
-    read_claude_endpoint_config, snapshot_active_credentials,
+    is_first_login, link_profile_credentials, live_credentials_are_shell, managed_env_key_label,
+    read_claude_credentials, read_claude_endpoint_config, snapshot_active_credentials,
 };
 use crate::lock::with_state_lock;
 use crate::lockorder::RankedMutex;
@@ -84,10 +84,15 @@ pub(crate) fn switch_profile(config: &mut AppConfig, name: &str) -> Result<()> {
         // switch. (Interactive callers already route a real divergence to the
         // reconcile path, so this branch is only reachable uncaptured via the
         // scheduler — where refusing, not dropping, is the safe outcome.)
+        // Claude Code's logged-out shell (both tokens blanked) is NOT an
+        // uncaptured re-login: there is no login in it to strand, and the
+        // non-force guard would otherwise refuse to replace the empty file,
+        // wedging every switch until a human resolves nothing in the TUI.
         let uncaptured_relogin = match config.state.active_profile.as_deref() {
             Some(active) => {
                 matches!(classify_credentials_link(active)?, LinkState::Diverged)
                     && !is_first_login(active)?
+                    && !live_credentials_are_shell()
             }
             None => false,
         };
@@ -135,11 +140,15 @@ pub(crate) fn switch_profile_cli(config: AppConfig, canonical: &str) -> Result<(
     let outgoing = config.state.active_profile.clone();
 
     // Diverged link = CC re-logged and wrote a regular file; must reconcile
-    // (capture into outgoing profile) rather than refuse.
+    // (capture into outgoing profile) rather than refuse. CC's logged-out
+    // shell (both tokens blanked) is exempt: capturing empty tokens over the
+    // outgoing profile's stored login would destroy it, so the shell takes the
+    // plain switch below and is replaced wholesale.
     let reconciled = match outgoing.as_deref() {
         Some(active) => {
             matches!(classify_credentials_link(active)?, LinkState::Diverged)
                 && !is_first_login(active)?
+                && !live_credentials_are_shell()
         }
         None => false,
     };
@@ -269,10 +278,14 @@ pub(crate) fn switch_profile_noninteractive(
         }
     }
 
+    // CC's logged-out shell (both tokens blanked) is not a divergence to
+    // resolve: no divergence default is consulted and the plain switch below
+    // replaces the empty file (same exemption as the CLI path above).
     let diverged = match previous.as_deref() {
         Some(active) => {
             matches!(classify_credentials_link(active)?, LinkState::Diverged)
                 && !is_first_login(active)?
+                && !live_credentials_are_shell()
         }
         None => false,
     };

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -116,6 +116,27 @@ pub(crate) fn read_claude_credentials() -> Result<Option<ClaudeCredentials>> {
     read_json_file(&path).map(Some)
 }
 
+/// True when the credentials hold NO usable login: no OAuth block, or one whose
+/// access AND refresh tokens are both absent/blank — Claude Code's logged-out
+/// shell (it blanks the tokens and zeroes `expiresAt` when its own refresh
+/// dies, keeping unrelated keys like `mcpOAuth`). A shell still classifies
+/// [`LinkState::Diverged`], but there is no login in it to protect.
+pub(crate) fn live_login_is_empty(creds: &ClaudeCredentials) -> bool {
+    creds.access_token().filter(|t| !t.is_empty()).is_none()
+        && creds.refresh_token().filter(|t| !t.is_empty()).is_none()
+}
+
+/// True when the live `.credentials.json` currently parses to such a logged-out
+/// shell. An unreadable or non-JSON file reads `false` — it may be a Claude
+/// Code write in progress, and "possibly a login" keeps the same protection as
+/// a real one (the divergence guards stay armed).
+pub(crate) fn live_credentials_are_shell() -> bool {
+    matches!(
+        read_claude_credentials(),
+        Ok(Some(live)) if live_login_is_empty(&live)
+    )
+}
+
 /// macOS: mirror a profile's stored OAuth login into the Keychain so Claude Code
 /// (which reads the Keychain, not the file) actually switches account. No-op when
 /// the profile has no stored `credentials.json` (a base_url profile, whose

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -35,6 +35,7 @@ use anyhow::{Context, Result};
 
 use crate::claude::{
     LinkState, classify_credentials_link, is_first_login, link_profile_credentials,
+    live_credentials_are_shell,
 };
 use crate::lockorder::RankedMutex;
 use crate::logline::logline;
@@ -194,11 +195,19 @@ pub(crate) fn status_oneshot() -> Result<()> {
 /// True when the live credentials diverge from the active profile's stored chain
 /// and it isn't a first-login adoption — the daemon cannot prompt, so it skips
 /// the switch and leaves the resolution to the operator (TUI Divergence modal).
+///
+/// Claude Code's logged-out shell (both tokens blanked after its own refresh
+/// died) is exempt: it classifies Diverged, but an empty login is not
+/// "unsaved credentials" — deferring on it wedges every headless switch behind
+/// a TUI decision about nothing while running sessions sit at "Login expired"
+/// (observed 2026-07-15). An unreadable/unparseable live file still defers:
+/// it may be a CC write in progress.
 fn active_diverged_unsaved(active: &str) -> bool {
     matches!(
         classify_credentials_link(active).ok(),
         Some(LinkState::Diverged)
     ) && !is_first_login(active).unwrap_or(false)
+        && !live_credentials_are_shell()
 }
 
 /// Owns the shared `Arc` stores (cloned into the scheduler) plus main-loop-only

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -196,12 +196,11 @@ pub(crate) fn status_oneshot() -> Result<()> {
 /// and it isn't a first-login adoption — the daemon cannot prompt, so it skips
 /// the switch and leaves the resolution to the operator (TUI Divergence modal).
 ///
-/// Claude Code's logged-out shell (both tokens blanked after its own refresh
-/// died) is exempt: it classifies Diverged, but an empty login is not
-/// "unsaved credentials" — deferring on it wedges every headless switch behind
-/// a TUI decision about nothing while running sessions sit at "Login expired"
-/// (observed 2026-07-15). An unreadable/unparseable live file still defers:
-/// it may be a CC write in progress.
+/// A logged-out shell (see [`live_credentials_are_shell`]) is exempt: an empty
+/// login is not "unsaved credentials", and deferring on it wedges every
+/// headless switch behind a TUI decision about nothing while running sessions
+/// sit at "Login expired" (observed 2026-07-15). An unreadable/torn live file
+/// still defers — it may be a CC write in progress.
 fn active_diverged_unsaved(active: &str) -> bool {
     matches!(
         classify_credentials_link(active).ok(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -32,7 +32,7 @@ use crate::claude::{
     LinkState, adopt_first_login, classify_credentials_link, claude_settings_env_keys,
     credentials_diverged, detach_credentials_link, force_link_profile_credentials,
     force_snapshot_active_credentials, is_first_login, link_profile_credentials,
-    read_claude_credentials, snapshot_active_credentials,
+    live_credentials_are_shell, read_claude_credentials, snapshot_active_credentials,
 };
 use crate::fallback::{DEFAULT_THRESHOLD, SwitchAction, auto_switch_if_needed, threshold_for};
 use crate::lock::with_state_lock;
@@ -3241,11 +3241,15 @@ where
 
 /// True when the live credentials diverge from the stored chain and it's not a
 /// first-login adoption (must be reconciled before clearing/relinking).
+/// Claude Code's logged-out shell (both tokens blanked) is exempt — an empty
+/// login needs no reconciling, and blocking a switch on it would defer the
+/// action behind a Divergence decision about nothing.
 fn active_diverged_unsaved(active: &str) -> bool {
     matches!(
         classify_credentials_link(active).ok(),
         Some(LinkState::Diverged)
     ) && !is_first_login(active).unwrap_or(false)
+        && !live_credentials_are_shell()
 }
 
 /// Toast and raise the Divergence prompt for `active` (`verb` = blocked action).
@@ -6838,6 +6842,15 @@ fn poll_credentials_divergence(app: &mut App) {
         Some(LinkState::Diverged)
     ) {
         app.divergence_pending = None; // resolved; a later divergence re-flags
+        return;
+    }
+    // Claude Code's logged-out shell (both tokens blanked after its own
+    // refresh died) is not an unsaved login: nothing to capture, nothing to
+    // resolve — don't nag, and never let a `default_divergence` Overwrite
+    // "capture" empty tokens over the profile's stored chain. The next switch
+    // replaces the shell wholesale.
+    if live_credentials_are_shell() {
+        app.divergence_pending = None;
         return;
     }
     // First login on a credential-less profile: adopt silently, don't prompt.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3240,10 +3240,8 @@ where
 }
 
 /// True when the live credentials diverge from the stored chain and it's not a
-/// first-login adoption (must be reconciled before clearing/relinking).
-/// Claude Code's logged-out shell (both tokens blanked) is exempt — an empty
-/// login needs no reconciling, and blocking a switch on it would defer the
-/// action behind a Divergence decision about nothing.
+/// first-login adoption (must be reconciled before clearing/relinking). A
+/// logged-out shell is exempt — an empty login needs no reconciling.
 fn active_diverged_unsaved(active: &str) -> bool {
     matches!(
         classify_credentials_link(active).ok(),
@@ -6844,11 +6842,8 @@ fn poll_credentials_divergence(app: &mut App) {
         app.divergence_pending = None; // resolved; a later divergence re-flags
         return;
     }
-    // Claude Code's logged-out shell (both tokens blanked after its own
-    // refresh died) is not an unsaved login: nothing to capture, nothing to
-    // resolve — don't nag, and never let a `default_divergence` Overwrite
-    // "capture" empty tokens over the profile's stored chain. The next switch
-    // replaces the shell wholesale.
+    // A logged-out shell is nothing to resolve: don't nag, and never let a
+    // `default_divergence` Overwrite capture its blank tokens over the stored chain.
     if live_credentials_are_shell() {
         app.divergence_pending = None;
         return;

--- a/tests/inline/claude.rs
+++ b/tests/inline/claude.rs
@@ -445,3 +445,82 @@ fn build_settings_clears_stale_model_knobs() {
     assert!(v["env"].get("CLAUDE_CODE_SUBAGENT_MODEL").is_none());
     assert_eq!(v["env"]["KEEP"], "1", "unrelated env keys are preserved");
 }
+
+// ── logged-out shell detection ────────────────────────────────────────────────
+//
+// When Claude Code's own token refresh dies it does not delete the live
+// `.credentials.json`: it blanks both tokens and zeroes `expiresAt`, keeping
+// unrelated keys like `mcpOAuth` — a logged-out shell. A shell still
+// classifies Diverged, so without the exemption every guard built on
+// "diverged and unsaved" deferred switches behind a TUI decision about an
+// empty file.
+
+/// Truth table for [`live_login_is_empty`]: only a login with NO usable token
+/// (both absent or blank, or no OAuth block at all) is empty — one live token
+/// on either side keeps the login's protections.
+#[test]
+fn live_login_is_empty_truth_table() {
+    // CC's logged-out shell: both tokens blanked.
+    assert!(live_login_is_empty(&creds("", Some(""))));
+    // Blank access token and no refresh token at all.
+    assert!(live_login_is_empty(&creds("", None)));
+    // No OAuth block (a file holding only foreign keys like mcpOAuth).
+    assert!(live_login_is_empty(&ClaudeCredentials {
+        claude_ai_oauth: None,
+    }));
+    // A live access token alone is a login.
+    assert!(!live_login_is_empty(&creds("at-live", None)));
+    assert!(!live_login_is_empty(&creds("at-live", Some(""))));
+    // A refresh token alone is a login (the access side merely expired).
+    assert!(!live_login_is_empty(&creds("", Some("rt-live"))));
+    // A full pair is a login.
+    assert!(!live_login_is_empty(&creds("at-live", Some("rt-live"))));
+}
+
+/// [`live_credentials_are_shell`] is true only for a PARSED empty login: a
+/// missing file is not a shell, and an unreadable/non-JSON file is not a shell
+/// either (it may be a CC write in progress — "possibly a login" must keep a
+/// real login's protections).
+#[test]
+fn live_credentials_are_shell_requires_a_parsed_empty_login() {
+    let _home = crate::testutil::HomeSandbox::new();
+    let live = claude_credentials_path().expect("creds path");
+    fs::create_dir_all(live.parent().expect("parent")).expect("mkdir .claude");
+
+    // Missing file: nothing there to call a shell.
+    assert!(!live_credentials_are_shell());
+
+    // CC's logged-out shell, foreign keys and all.
+    fs::write(
+        &live,
+        serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "",
+                "refreshToken": "",
+                "expiresAt": 0,
+                "scopes": ["user:inference"],
+                "subscriptionType": "max",
+            },
+            "mcpOAuth": { "some-server": { "accessToken": "mcp-tok" } },
+        })
+        .to_string(),
+    )
+    .expect("write shell");
+    assert!(live_credentials_are_shell());
+
+    // No OAuth block at all is the same shell.
+    fs::write(&live, r#"{"mcpOAuth":{}}"#).expect("write oauth-less file");
+    assert!(live_credentials_are_shell());
+
+    // Torn JSON (a write in progress): NOT a shell — guards stay armed.
+    fs::write(&live, br#"{"claudeAiOauth":{"accessToken":""#).expect("write torn file");
+    assert!(!live_credentials_are_shell());
+
+    // A real login: not a shell.
+    fs::write(
+        &live,
+        serde_json::to_vec(&creds("at-live", Some("rt-live"))).expect("ser live"),
+    )
+    .expect("write live");
+    assert!(!live_credentials_are_shell());
+}

--- a/tests/inline/daemon_mod.rs
+++ b/tests/inline/daemon_mod.rs
@@ -211,6 +211,116 @@ fn drain_pending_switch_skips_on_active_divergence() {
     );
 }
 
+/// Claude Code's logged-out SHELL (both tokens blanked, `expiresAt: 0` — what
+/// CC writes when its own refresh dies, keeping unrelated keys like
+/// `mcpOAuth`) still classifies Diverged, but holds no login to protect. The
+/// queued switch must PROCEED over it — deferring wedged every headless
+/// switch behind a TUI decision about an empty file while running sessions
+/// sat at "Login expired" (observed 2026-07-15).
+#[test]
+fn drain_pending_switch_proceeds_over_a_logged_out_shell() {
+    let _home = HomeSandbox::new();
+    let config = persist(
+        vec![
+            profile_with_creds("alpha", "at-alpha"),
+            profile_with_creds("beta", "at-beta"),
+        ],
+        Some("alpha"),
+        90_000,
+    );
+    let dir = claude_dir().expect("claude dir");
+    std::fs::create_dir_all(&dir).expect("mkdir ~/.claude");
+    let live = dir.join(".credentials.json");
+    std::fs::write(
+        &live,
+        serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "",
+                "refreshToken": "",
+                "expiresAt": 0,
+                "scopes": ["user:inference"],
+                "subscriptionType": "max",
+            },
+            "mcpOAuth": { "some-server": { "accessToken": "mcp-tok" } },
+        })
+        .to_string(),
+    )
+    .expect("write live shell");
+    let mut daemon = daemon_for(config);
+
+    stage_switch(&daemon, "beta");
+    daemon.drain_pending_switch();
+
+    assert_eq!(
+        active_of(&daemon).as_deref(),
+        Some("beta"),
+        "a token-less shell must not block the switch"
+    );
+    // The shell was replaced by beta's stored login (symlink on unix, copy on
+    // Windows — assert through the content, not the link type).
+    let installed: ClaudeCredentials =
+        crate::profile::read_json_file(&live).expect("read installed live credentials");
+    assert_eq!(
+        installed.access_token(),
+        Some("at-beta"),
+        "the live slot now holds the target's stored login"
+    );
+    // The empty shell was never captured over the outgoing store.
+    let alpha_store = crate::profile::profile_dir("alpha")
+        .expect("alpha dir")
+        .join("credentials.json");
+    let stored: ClaudeCredentials =
+        crate::profile::read_json_file(&alpha_store).expect("read alpha store");
+    assert_eq!(
+        stored.access_token(),
+        Some("at-alpha"),
+        "the shell's blank tokens must never overwrite the outgoing profile's stored login"
+    );
+    assert_eq!(
+        queued_targets(&daemon),
+        Vec::<String>::new(),
+        "the executed switch leaves nothing queued"
+    );
+}
+
+/// A live file that does not PARSE is not a shell — it may be a CC write in
+/// progress, i.e. possibly a login. The divergence deferral stays armed for
+/// it, exactly like a real diverged login.
+#[test]
+fn drain_pending_switch_still_defers_on_a_torn_live_file() {
+    let _home = HomeSandbox::new();
+    let config = persist(
+        vec![
+            profile_with_creds("alpha", "at-alpha"),
+            profile_with_creds("beta", "at-beta"),
+        ],
+        Some("alpha"),
+        90_000,
+    );
+    let dir = claude_dir().expect("claude dir");
+    std::fs::create_dir_all(&dir).expect("mkdir ~/.claude");
+    std::fs::write(
+        dir.join(".credentials.json"),
+        br#"{"claudeAiOauth":{"accessToken":""#,
+    )
+    .expect("write torn live file");
+    let mut daemon = daemon_for(config);
+
+    stage_switch(&daemon, "beta");
+    daemon.drain_pending_switch();
+
+    assert_eq!(
+        active_of(&daemon).as_deref(),
+        Some("alpha"),
+        "an unreadable live file keeps the deferral (mid-write caution)"
+    );
+    assert_eq!(
+        queued_targets(&daemon),
+        vec!["beta".to_string()],
+        "the deferred switch stays queued for retry"
+    );
+}
+
 /// A queued switch whose target no longer resolves (deleted out-of-process
 /// after the enqueue — `clauth delete` can't purge this daemon's in-memory
 /// queue) is DROPPED with a last_error, never attempted. Pre-fix, the drain

--- a/tests/inline/mcp_switch.rs
+++ b/tests/inline/mcp_switch.rs
@@ -186,6 +186,64 @@ fn divergence_overwrite_captures_relogin_into_outgoing() {
     );
 }
 
+/// A logged-out shell (both tokens blanked) classifies Diverged but holds no
+/// login: even the most dangerous default (`Overwrite`) must NOT capture its
+/// blank tokens over the outgoing profile's stored login — the switch takes the
+/// plain path and replaces the shell wholesale.
+#[test]
+fn divergence_over_a_shell_switches_without_capturing() {
+    let _home = HomeSandbox::new();
+    let shell = creds("", "");
+    let config = handle(seed_diverged(
+        "active",
+        creds("stored-a", "stored-r"),
+        &shell,
+        "target",
+        Some(creds("target-a", "target-r")),
+    ));
+
+    // Positive control: the shell must be on the Diverged path the exemption
+    // bypasses — otherwise this test would pass without exercising it.
+    assert_eq!(
+        classify_credentials_link("active").unwrap(),
+        LinkState::Diverged,
+        "a blank-token shell still classifies Diverged",
+    );
+
+    let (previous, active) = switch_profile_noninteractive(
+        &config,
+        "target",
+        Some(DivergenceChoice::Overwrite),
+        no_network,
+    )
+    .expect("shell switch proceeds");
+    assert_eq!(previous.as_deref(), Some("active"));
+    assert_eq!(active, "target");
+
+    // The shell's blanks were never captured over the outgoing store.
+    let outgoing: ClaudeCredentials =
+        read_json_file(&profile_dir("active").unwrap().join("credentials.json"))
+            .expect("read outgoing creds");
+    assert_eq!(
+        outgoing.refresh_token(),
+        Some("stored-r"),
+        "Overwrite over a shell must not destroy the outgoing profile's stored login",
+    );
+
+    // …and the live link ends pointing at target's stored creds.
+    let live_now: ClaudeCredentials = read_json_file(
+        &crate::profile::claude_dir()
+            .unwrap()
+            .join(".credentials.json"),
+    )
+    .expect("read live creds");
+    assert_eq!(
+        live_now.refresh_token(),
+        Some("target-r"),
+        "the switch replaces the shell with target's stored login",
+    );
+}
+
 #[test]
 fn divergence_discard_drops_relogin_and_relinks_target() {
     let _home = HomeSandbox::new();

--- a/tests/inline/tui_app.rs
+++ b/tests/inline/tui_app.rs
@@ -1274,6 +1274,51 @@ fn divergence_flags_the_banner_and_never_blocks_the_tui() {
     assert!(app.modals.is_empty(), "d is a no-op with no divergence");
 }
 
+/// Claude Code's logged-out shell (both tokens blanked after its own refresh
+/// died) is not an unsaved login: the poll must not flag the banner, and a
+/// configured `default_divergence` must never "capture" the empty tokens over
+/// the profile's stored chain.
+#[test]
+fn divergence_poll_ignores_a_logged_out_shell() {
+    use crate::profile::{AppConfig, AppState, DivergenceChoice, Profile, save_profile};
+    let _home = crate::testutil::HomeSandbox::new();
+
+    let mut work = Profile::new("work".to_string(), None, None);
+    work.credentials = Some(login_creds("rt-work"));
+    save_profile(&work).expect("save work");
+    // CC's logged-out shell: both tokens blanked. Still classifies Diverged.
+    write_live_creds(&creds_ra("", ""));
+
+    let mut app = App::new(AppConfig {
+        state: AppState {
+            active_profile: Some("work".into()),
+            profiles: vec!["work".into()],
+            // The most dangerous configuration: an auto-resolving default
+            // that would capture the live file into the profile.
+            default_divergence: Some(DivergenceChoice::Overwrite),
+            ..AppState::default()
+        },
+        profiles: vec![work],
+    });
+
+    force_poll(&mut app);
+    assert!(
+        app.divergence_pending.is_none(),
+        "an empty shell is nothing to resolve — no banner"
+    );
+    assert!(app.modals.is_empty(), "and certainly no modal");
+    let stored = crate::profile::profile_dir("work")
+        .expect("work dir")
+        .join("credentials.json");
+    let stored: crate::profile::ClaudeCredentials =
+        crate::profile::read_json_file(&stored).expect("read work store");
+    assert_eq!(
+        stored.refresh_token(),
+        Some("rt-work"),
+        "the divergence default must never capture blank tokens over the stored login"
+    );
+}
+
 /// The banner and the resolver both identify the live login's OWNER when it is
 /// a stored sibling — by exact token match here (the half-landed-switch shape)
 /// — and the resolver leads with the "switch to it" action.


### PR DESCRIPTION
Caught this live on 2026-07-15, on a headless box running the daemon.

## The wedge

When Claude Code's **own** token refresh dies, it doesn't delete the live `~/.claude/.credentials.json` — it writes a **logged-out shell**: `accessToken: ""`, `refreshToken: ""`, `expiresAt: 0`, with unrelated keys like `mcpOAuth` kept in place. That shell still classifies `LinkState::Diverged`, so every guard built on "diverged and unsaved" treated an empty file as a login someone must resolve:

- the daemon deferred every queued auto-switch (`active '<name>' has unsaved credentials; resolve in the TUI`) — on a headless box, forever;
- `switch_profile`'s non-force link refused to replace the file, so even the escape hatch was wedged;
- the TUI banner nagged about credentials that don't exist, and a configured `default_divergence: Overwrite` would happily "capture" the blank tokens **over the profile's stored login**, destroying it.

Meanwhile every running `claude` sat at "Login expired" behind a file with nothing in it.

## The fix

The divergence guards exist to protect a live login the operator may hold nowhere else. A shell holds no login, so it forfeits that protection — and nothing else changes.

- `claude::live_login_is_empty(&creds)`: no OAuth block, or access AND refresh both absent/blank.
- `claude::live_credentials_are_shell()`: the live file **parses** to such an empty login.
- Every "unsaved credentials" predicate gets the one-line exemption: the daemon deferral (`active_diverged_unsaved`), its TUI twin, `switch_profile`'s uncaptured-relogin guard (so the switch takes the force-link and replaces the shell wholesale), the CLI `[Y/n]` reconcile prompt (capturing blank tokens over the outgoing store would destroy it), and the headless/MCP divergence-default branch. The TUI's 1Hz poll also skips the shell: no banner, and `default_divergence` can never capture it.

**Mid-write caution retained**: only a file that *parses* to an empty login is a shell. An unreadable or torn live file is "possibly a login mid-write" and keeps the full deferral, exactly like a real diverged login. A real re-login (either token non-blank) keeps every existing protection — the reclaim-vs-protect line is "the endpoint of both tokens is provably nothing", decided offline by the file's own content.

## Tests

- `live_login_is_empty` truth table (blank pair / blank access only / no OAuth block → empty; any single live token → not empty).
- `live_credentials_are_shell` requires a *parsed* empty login: missing file, torn JSON, and a real login all read false.
- Daemon: a queued switch **proceeds** over a shell (lands the target's stored login in the live slot, never captures the blanks over the outgoing store, leaves nothing queued); a torn live file **still defers** and stays queued; the existing `drain_pending_switch_skips_on_active_divergence` keeps pinning the real-divergence deferral.
- TUI: the poll ignores a shell — no banner, and `default_divergence: Overwrite` leaves the stored chain untouched.

944 tests, `fmt`, `clippy -D warnings` clean.

This is the minimal standalone piece of a bigger incident class (a diverged live login whose owner can't be proven locally); I'll write that up separately as an issue rather than smuggle it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)