### PR TITLE
feat(tui): narrow-terminal (phone ≈45 col) adaptation — stack, don't truncate

### DIFF
--- a/src/tui/render/chain.rs
+++ b/src/tui/render/chain.rs
@@ -11,7 +11,7 @@
 //! confirms. No popups.
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
@@ -22,8 +22,8 @@ use super::super::app::{
 use super::super::theme;
 use super::panes::{
     bold_when, draw_selector_list, head_cols, help_tooltip_lines, highlight_row,
-    invalid_tooltip_lines, key_cell, label_style, name_color, section_box, section_box_verbatim,
-    select_line, selector_width, wrap_words,
+    invalid_tooltip_lines, key_cell, label_style, master_detail, name_color, section_box,
+    section_box_verbatim, select_line, wrap_words,
 };
 use crate::fallback::{
     BlockedReason, DEFAULT_THRESHOLD, blocked_reason, soonest_resume, spend_is_uncapped,
@@ -51,15 +51,11 @@ const ROWS_BEFORE: usize = 5;
 const PILL_LINES: usize = 2;
 
 pub(super) fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    let [selector_area, detail_area] = Layout::horizontal([
-        Constraint::Length(selector_width(area.width)),
-        Constraint::Min(20),
-    ])
-    .areas(area);
+    let (selector, detail) = master_detail(area, chain_items(app).len());
 
     let chain_focused = app.fallback_focus == FallbackFocus::Chain;
-    draw_chain_selector(frame, selector_area, app, chain_focused);
-    draw_chain_detail(frame, detail_area, app);
+    draw_chain_selector(frame, selector, app, chain_focused);
+    draw_chain_detail(frame, detail, app);
 }
 
 fn draw_chain_selector(frame: &mut Frame<'_>, area: Rect, app: &App, focused: bool) {

--- a/src/tui/render/config.rs
+++ b/src/tui/render/config.rs
@@ -5,7 +5,7 @@
 //! pane into a create form. No popups.
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
@@ -15,8 +15,8 @@ use super::super::app::{
 use super::super::theme;
 use super::panes::{
     bold_when, cycle_option, draw_scrolled_lines, draw_selector_list, head_cols,
-    help_tooltip_lines, highlight_row, key_cell, label_style, name_color, picker_row, section_box,
-    section_box_verbatim, selector_width,
+    help_tooltip_lines, highlight_row, key_cell, label_style, master_detail, name_color,
+    picker_row, section_box, section_box_verbatim,
 };
 
 const KEY_W: usize = 11;
@@ -24,15 +24,13 @@ const KEY_W: usize = 11;
 const KEY_GUTTER: usize = 2;
 
 pub(super) fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    let [selector_area, settings_area] = Layout::horizontal([
-        Constraint::Length(selector_width(area.width)),
-        Constraint::Min(20),
-    ])
-    .areas(area);
+    // +1 for the trailing `+ new` picker row.
+    let items = app.config().profiles.len() + 1;
+    let (selector, settings) = master_detail(area, items);
 
     let profiles_focused = app.config_focus == ConfigFocus::Profiles;
-    draw_selector(frame, selector_area, app, profiles_focused);
-    draw_settings(frame, settings_area, app);
+    draw_selector(frame, selector, app, profiles_focused);
+    draw_settings(frame, settings, app);
 }
 
 fn draw_selector(frame: &mut Frame<'_>, area: Rect, app: &App, focused: bool) {

--- a/src/tui/render/footer.rs
+++ b/src/tui/render/footer.rs
@@ -240,6 +240,29 @@ pub(super) fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
         hints.push(("q", q_label));
     }
 
+    // Measured degradation for narrow terminals: while the row overflows, drop
+    // the rightmost non-essential hint. Navigation (`←→`), discoverability
+    // (`? help`), exits (`q`/`esc`) and armed confirms always survive; on a
+    // desktop-width terminal everything fits and nothing changes.
+    let row_width = |hints: &[(&str, &str)]| -> usize {
+        let cells: usize = hints
+            .iter()
+            .map(|(k, l)| k.chars().count() + 1 + l.chars().count())
+            .sum();
+        cells + hints.len().saturating_sub(1) * 3
+    };
+    let essential = |(key, label): &(&str, &str)| {
+        matches!(*key, "←→" | "?" | "q" | "esc") || label.starts_with("confirm")
+    };
+    while row_width(&hints) > area.width as usize {
+        match hints.iter().rposition(|h| !essential(h)) {
+            Some(i) => {
+                hints.remove(i);
+            }
+            None => break,
+        }
+    }
+
     let mut spans: Vec<Span<'_>> = Vec::new();
     for (i, (key, label)) in hints.iter().enumerate() {
         if i > 0 {

--- a/src/tui/render/header.rs
+++ b/src/tui/render/header.rs
@@ -233,11 +233,7 @@ pub(super) fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
     // The count + gauge are left-aligned together; the status dot is the
     // only thing right-aligned, with an elastic gap in between.
     let row1_width = rows[1].width as usize;
-    let prefix = if gauge.is_some() {
-        format!("{n} account{} · ", plural(n))
-    } else {
-        format!("{n} account{}", plural(n))
-    };
+    let prefix = format!("{n} account{}", plural(n));
     let feed = "status.claude.ai";
     let status_head = "● ";
     let status_w = status_head.chars().count() + feed.chars().count();
@@ -245,17 +241,22 @@ pub(super) fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
     let mut left_spans: Vec<Span<'static>> = vec![Span::styled(prefix, theme::faint())];
     if let Some(ref g) = gauge {
+        // The ` · ` separator is budgeted here but only rendered when the gauge
+        // survives the fit — a hidden gauge must not leave a dangling dot.
+        let sep = " · ";
         let gauge_budget = row1_width.saturating_sub(
             left_spans
                 .iter()
                 .map(|s| s.content.chars().count())
                 .sum::<usize>()
+                + sep.chars().count()
                 + status_w
                 + reserve,
         );
         let fit = gauge_fit(gauge_budget, g.name.chars().count(), g.pct.is_some());
         if fit.visible {
             let elapsed = app.started_at.elapsed().as_millis() as u64;
+            left_spans.push(Span::styled(sep.to_string(), theme::faint()));
             left_spans.extend(gauge_spans(fit, &g.name, g.pct, elapsed));
         }
     }

--- a/src/tui/render/modals.rs
+++ b/src/tui/render/modals.rs
@@ -93,11 +93,23 @@ fn centered(area: Rect, width: u16, height: u16) -> Rect {
 
 /// Modal sized to content: snaps to widest line/title, exact line count.
 /// Chrome = rounded border (1) + `Padding::new(2,2,1,1)` = 6 cols, 4 rows.
+///
+/// A line wider than the modal's inner width (only possible on a terminal
+/// too narrow for the content) is pre-split into inner-width rows by
+/// [`chunk_line`], so the height is exact by construction — ratatui's own
+/// word-wrap may use MORE rows than any cheap estimate and silently clip the
+/// tail. On any terminal wide enough for the content nothing splits and the
+/// modal renders exactly as before.
 fn draw_modal(frame: &mut Frame<'_>, area: Rect, title: &str, lines: Vec<Line<'_>>) {
     let content_w = lines.iter().map(Line::width).max().unwrap_or(0) as u16;
     let w = (content_w + 6)
         .max(title.chars().count() as u16 + 4)
         .min(area.width.saturating_sub(4));
+    let inner_w = (w.saturating_sub(6) as usize).max(1);
+    let lines: Vec<Line<'static>> = lines
+        .into_iter()
+        .flat_map(|l| chunk_line(l, inner_w))
+        .collect();
     let h = (lines.len() as u16 + 4).min(area.height.saturating_sub(4));
 
     let rect = centered(area, w, h);
@@ -106,6 +118,56 @@ fn draw_modal(frame: &mut Frame<'_>, area: Rect, title: &str, lines: Vec<Line<'_
     let inner = block.inner(rect);
     frame.render_widget(block, rect);
     frame.render_widget(Paragraph::new(lines).style(theme::base()), inner);
+}
+
+/// Split one styled line into `w`-column rows by character, preserving span
+/// styles and the line's alignment/style. A line that already fits returns
+/// itself (owned) untouched. Modal copy is ASCII, so chars ≈ display cells.
+fn chunk_line(line: Line<'_>, w: usize) -> Vec<Line<'static>> {
+    let own = |l: &Line<'_>| -> Line<'static> {
+        let mut out = Line::from(
+            l.spans
+                .iter()
+                .map(|s| Span::styled(s.content.to_string(), s.style))
+                .collect::<Vec<_>>(),
+        )
+        .style(l.style);
+        out.alignment = l.alignment;
+        out
+    };
+    if w == 0 || line.width() <= w {
+        return vec![own(&line)];
+    }
+
+    let mut rows: Vec<Line<'static>> = Vec::new();
+    let mut cur: Vec<Span<'static>> = Vec::new();
+    let mut used = 0usize;
+    let mut flush = |cur: &mut Vec<Span<'static>>| {
+        let mut row = Line::from(std::mem::take(cur)).style(line.style);
+        row.alignment = line.alignment;
+        rows.push(row);
+    };
+    for span in &line.spans {
+        let mut buf = String::new();
+        for ch in span.content.chars() {
+            if used == w {
+                if !buf.is_empty() {
+                    cur.push(Span::styled(std::mem::take(&mut buf), span.style));
+                }
+                flush(&mut cur);
+                used = 0;
+            }
+            buf.push(ch);
+            used += 1;
+        }
+        if !buf.is_empty() {
+            cur.push(Span::styled(buf, span.style));
+        }
+    }
+    if !cur.is_empty() {
+        flush(&mut cur);
+    }
+    rows
 }
 
 /// Rounded `ACCENT_2` border, uppercase italic dim title, base `BG` fill.

--- a/src/tui/render/overview.rs
+++ b/src/tui/render/overview.rs
@@ -404,6 +404,7 @@ fn fallback_flow_lines(app: &App, width: usize) -> Vec<Line<'static>> {
     // Switch-grade kick blocks feed the blocked-reason markers; read BEFORE the
     // Config lock (rank order: KickBlockState 230 < Config 400).
     let kick_lifts = switch_grade_kick_lifts(&app.kick_blocks);
+    let narrow = super::panes::narrow(width as u16);
     let cfg = app.config();
     if cfg.state.fallback_chain.is_empty() {
         let mut lines = vec![Line::from(Span::styled(
@@ -423,12 +424,14 @@ fn fallback_flow_lines(app: &App, width: usize) -> Vec<Line<'static>> {
     }
 
     let chain = &cfg.state.fallback_chain;
+    // Narrow: tighter name clamp + a gauge sized from what's left, so a chain
+    // row fits a phone line instead of hard-wrapping its trailing figures.
     let name_w = chain
         .iter()
         .map(|n| n.chars().count())
         .max()
         .unwrap_or(8)
-        .clamp(6, 18);
+        .clamp(6, if narrow { 12 } else { 18 });
     // Threshold digits vary across members (`95%` vs `100%`), so left-pad them to
     // the widest so the `%` signs line up (cloudy-tui numeric-column alignment).
     // It also makes every row's content the same width, which is what lets the
@@ -440,6 +443,18 @@ fn fallback_flow_lines(app: &App, width: usize) -> Vec<Line<'static>> {
         .max()
         .unwrap_or(3);
     let last = chain.len() - 1;
+    let gauge_w = if narrow {
+        // Exact-fit budget against chain_row's spans: ` ╭ `(3) + `N `(digits+1)
+        // + name(name_w+2) + figure `  100`(5) + ` / 100%`(7, 3-digit worst).
+        // Trailers (hint/marker) only render when the base leaves room, so a
+        // narrow line keeps its figures on one row instead of hard-wrapping.
+        let idx_w = (last + 1).to_string().chars().count() + 1;
+        width
+            .saturating_sub(3 + idx_w + name_w + 2 + 5 + 7)
+            .clamp(4, GAUGE_W)
+    } else {
+        GAUGE_W
+    };
 
     // Project the active profile's next switch once, up front: a `To(target)`
     // renders inline on the target member's row (right side); `Off` has no
@@ -464,7 +479,9 @@ fn fallback_flow_lines(app: &App, width: usize) -> Vec<Line<'static>> {
                 .as_ref()
                 .filter(|(target, _)| target.as_str() == name.as_str())
                 .map(|(_, secs)| *secs);
-            chain_row(&cfg, name, i, last, name_w, thr_w, reason, switch_eta)
+            chain_row(
+                &cfg, name, i, last, name_w, gauge_w, thr_w, reason, switch_eta,
+            )
         })
         .collect();
     let trailer_col = rows.iter().map(ChainRow::base_width).max().unwrap_or(0) + TRAILER_GAP;
@@ -601,6 +618,7 @@ fn chain_row(
     index: usize,
     last: usize,
     name_w: usize,
+    gauge_w: usize,
     thr_w: usize,
     reason: Option<BlockedReason>,
     switch_eta: Option<i64>,
@@ -638,7 +656,7 @@ fn chain_row(
                 .as_ref()
                 .and_then(|u| u.five_hour.as_ref())
                 .map(|w| w.utilization);
-            spans.extend(gauge_spans(pct, threshold));
+            spans.extend(gauge_spans(pct, threshold, gauge_w));
             let (figure, figure_style) = match pct {
                 Some(v) => (
                     format!("  {v:>3.0}"),
@@ -662,8 +680,9 @@ fn chain_row(
     }
 }
 
-/// `GAUGE_W`-cell bar relative to the member's threshold (full = rotate off).
-fn gauge_spans(pct: Option<f64>, threshold: f64) -> Vec<Span<'static>> {
+/// `gauge_w`-cell bar relative to the member's threshold (full = rotate off).
+/// `GAUGE_W` on desktop; narrow rows pass what their line has left.
+fn gauge_spans(pct: Option<f64>, threshold: f64, gauge_w: usize) -> Vec<Span<'static>> {
     let fill = pct
         .map(|v| {
             let frac = if threshold > 0.0 {
@@ -671,15 +690,15 @@ fn gauge_spans(pct: Option<f64>, threshold: f64) -> Vec<Span<'static>> {
             } else {
                 1.0
             };
-            (frac * GAUGE_W as f64).round() as usize
+            (frac * gauge_w as f64).round() as usize
         })
         .unwrap_or(0)
-        .min(GAUGE_W);
+        .min(gauge_w);
     let fill_color = pct
         .map(theme::util_color)
         .unwrap_or(theme::text_faint_color());
 
-    (0..GAUGE_W)
+    (0..gauge_w)
         .map(|i| {
             if i < fill {
                 Span::styled("▰", Style::default().fg(fill_color))

--- a/src/tui/render/panes.rs
+++ b/src/tui/render/panes.rs
@@ -17,6 +17,47 @@ pub(super) fn selector_width(body_w: u16) -> u16 {
     (body_w.saturating_mul(3) / 10).clamp(20, 40)
 }
 
+/// Phone-width threshold: below this, layouts that place panes side-by-side
+/// stack them vertically instead — at Moshi's ~45 columns the horizontal
+/// master-detail split leaves the detail pane ~13 usable cells. At or above
+/// it every layout is byte-identical to the desktop rendering.
+pub(super) const NARROW_BODY_W: u16 = 60;
+
+/// True when `w` is under the phone-width threshold.
+pub(super) fn narrow(w: u16) -> bool {
+    w < NARROW_BODY_W
+}
+
+/// The master-detail pane split shared by the Usage/Setup/Fallback/Status/
+/// Plugin tabs. Desktop: the house horizontal selector|detail. Narrow: stacked
+/// selector-above-detail — the selector takes its `items` rows (+ box chrome)
+/// up to 40% of the body, the detail the rest, so both panes keep full-width
+/// lines on a phone. Rows, not columns, are the abundant resource there.
+pub(super) fn master_detail(area: Rect, items: usize) -> (Rect, Rect) {
+    use ratatui::layout::{Constraint, Direction, Layout};
+    if narrow(area.width) {
+        let max_sel = (area.height.saturating_mul(2) / 5).max(5);
+        let want = u16::try_from(items.saturating_add(3)).unwrap_or(u16::MAX);
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(want.clamp(5, max_sel)),
+                Constraint::Min(8),
+            ])
+            .split(area);
+        (rows[0], rows[1])
+    } else {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(selector_width(area.width)),
+                Constraint::Min(20),
+            ])
+            .split(area);
+        (cols[0], cols[1])
+    }
+}
+
 /// Display columns occupied by the text before the caret in `input`.
 /// `InputState::cursor` is a byte offset; every edited field is ASCII-only in
 /// practice, so the char count of the pre-caret slice equals display columns.

--- a/src/tui/render/plugin.rs
+++ b/src/tui/render/plugin.rs
@@ -12,7 +12,7 @@
 //! title spinner only flickers while the cached `claude --version` is probed.
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::symbols::border;
 use ratatui::text::{Line, Span};
@@ -21,18 +21,14 @@ use ratatui::widgets::{Block, Paragraph};
 use super::super::app::{App, Health, PluginFocus};
 use super::super::theme;
 use super::format::spinner_frame;
-use super::panes::{draw_scrollbar, empty_state, section_box, selector_width};
+use super::panes::{draw_scrollbar, empty_state, master_detail, section_box};
 use crate::format::truncate;
 
 pub(super) fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    let [selector_area, detail_area] = Layout::horizontal([
-        Constraint::Length(selector_width(area.width)),
-        Constraint::Min(20),
-    ])
-    .areas(area);
+    let (selector, detail) = master_detail(area, app.plugin.row_count());
 
-    draw_selector(frame, selector_area, app);
-    draw_detail(frame, detail_area, app);
+    draw_selector(frame, selector, app);
+    draw_detail(frame, detail, app);
 }
 
 // ── Left panel: checks + profiles selector ──────────────────────────────────────

--- a/src/tui/render/status.rs
+++ b/src/tui/render/status.rs
@@ -8,7 +8,7 @@
 //! a read-only timeline the list descends into with enter; up/down scrolls it.
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::symbols::border;
 use ratatui::text::{Line, Span};
@@ -17,9 +17,7 @@ use ratatui::widgets::{Block, Paragraph};
 use super::super::app::{App, StatusFocus};
 use super::super::theme;
 use super::format::{clock_label, relative_age, spinner_frame};
-use super::panes::{
-    draw_scrollbar, empty_state, key_cell, section_box, selector_width, wrap_words,
-};
+use super::panes::{draw_scrollbar, empty_state, key_cell, master_detail, section_box, wrap_words};
 use crate::status::{Impact, Incident, IncidentUpdate, UpdatePhase, shorten_component_status};
 
 /// Detail-pane key column width (matches the usage tab's `KEY_W`).
@@ -28,14 +26,11 @@ const KEY_W: usize = 11;
 const KEY_GUTTER: usize = 2;
 
 pub(super) fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    let [list_area, detail_area] = Layout::horizontal([
-        Constraint::Length(selector_width(area.width)),
-        Constraint::Min(20),
-    ])
-    .areas(area);
+    // Each incident renders two rows (title + phase pill) in the list.
+    let (list, detail) = master_detail(area, app.status.incidents.len() * 2);
 
-    draw_incident_list(frame, list_area, app);
-    draw_incident_detail(frame, detail_area, app);
+    draw_incident_list(frame, list, app);
+    draw_incident_detail(frame, detail, app);
 }
 
 // ── Left panel: incident list ─────────────────────────────────────────────────
@@ -345,9 +340,17 @@ fn detail_lines(incident: &Incident, inner_w: usize) -> Vec<Line<'static>> {
     if left_w + dur_str.chars().count() < inner_w {
         let gap = inner_w - left_w - dur_str.chars().count();
         header.push(Span::styled(" ".repeat(gap), Style::default()));
+        header.push(Span::styled(dur_str, theme::faint()));
+        lines.push(Line::from(header));
+    } else {
+        // No room to right-align: the duration drops to its own line instead
+        // of gluing onto the age (`…2026-06-06ongoing`).
+        lines.push(Line::from(header));
+        lines.push(Line::from(Span::styled(
+            format!("  {dur_str}"),
+            theme::faint(),
+        )));
     }
-    header.push(Span::styled(dur_str, theme::faint()));
-    lines.push(Line::from(header));
 
     // started row (the one place the `utc` suffix appears).
     lines.push(Line::from(vec![

--- a/src/tui/render/tokens.rs
+++ b/src/tui/render/tokens.rs
@@ -25,8 +25,8 @@ use super::super::app::{App, TokenFilter, TokenPeriod, TokenView, token_period_m
 use super::super::theme;
 use super::format::{fixed, spinner_frame};
 use super::panes::{
-    draw_selector_list, picker_row, section_box, section_box_loading, section_box_verbatim,
-    selector_width,
+    draw_selector_list, master_detail, picker_row, section_box, section_box_loading,
+    section_box_verbatim,
 };
 use crate::pricing::PriceTable;
 use crate::tokens::{
@@ -458,6 +458,32 @@ const CARD_COL_W: u16 = 56;
 /// `DASH_MAX_W` band (past it the percentage-split cards stretch their
 /// edge-anchored figures into scattered fragments).
 fn dash_rects(area: Rect) -> DashRects {
+    // Phone width: every card pair stacks — a 45-col terminal has no room for
+    // side-by-side cards (the TODAY card alone needs ~20 content cells). Rows
+    // are the abundant resource there; a short terminal clips the trailing
+    // charts (hour/activity) rather than crushing every card.
+    if super::panes::narrow(area.width) {
+        let rows = Layout::vertical([
+            Constraint::Length(6), // today / this week / this month
+            Constraint::Length(6), // total
+            Constraint::Length(4), // trend (compact)
+            Constraint::Length(7), // top models
+            Constraint::Length(6), // composition
+            Constraint::Length(9), // hour of day (24 buckets fit 45 cols)
+            Constraint::Min(0),    // activity takes whatever is left
+        ])
+        .split(area);
+        return DashRects {
+            first: rows[0],
+            total: rows[1],
+            trend: rows[2],
+            models: rows[3],
+            comp: rows[4],
+            hour: rows[5],
+            activity: rows[6],
+        };
+    }
+
     if area.width >= TWO_COL_MIN_W && area.height >= TWO_COL_MIN_H {
         let cols: [Rect; 2] =
             Layout::horizontal([Constraint::Length(CARD_COL_W), Constraint::Fill(1)]).areas(area);
@@ -1203,13 +1229,9 @@ fn kv_accent(label: &str, value: String) -> Line<'static> {
 // ── models master-detail view ──────────────────────────────────────────────
 
 fn draw_models(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    let cols: [Rect; 2] = Layout::horizontal([
-        Constraint::Length(selector_width(area.width)),
-        Constraint::Min(20),
-    ])
-    .areas(area);
-
     let grouped = token_period_models(app);
+    let (selector, detail) = master_detail(area, grouped.len());
+    let cols = [selector, detail];
     let sel = app.token_model_cursor.min(grouped.len().saturating_sub(1));
 
     // The selector title carries the active lenses so the narrowed list reads

--- a/src/tui/render/usage.rs
+++ b/src/tui/render/usage.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
@@ -14,8 +14,8 @@ use super::super::app::App;
 use super::super::theme;
 use super::format::{activity_verb, format_reset, spinner_frame, spinner_style};
 use super::panes::{
-    draw_profile_selector, empty_state, help_tooltip_lines, key_cell, section_box,
-    section_box_verbatim, selector_width,
+    draw_profile_selector, empty_state, help_tooltip_lines, key_cell, master_detail, section_box,
+    section_box_verbatim,
 };
 use crate::format::plan_label;
 use crate::profile::Profile;
@@ -71,14 +71,11 @@ struct HeaderState {
 }
 
 pub(super) fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    let [selector_area, detail_area] = Layout::horizontal([
-        Constraint::Length(selector_width(area.width)),
-        Constraint::Min(20),
-    ])
-    .areas(area);
+    let items = app.config().profiles.len();
+    let (selector, detail) = master_detail(area, items);
 
-    draw_profile_selector(frame, selector_area, app, app.profile_cursor, true);
-    draw_usage_detail(frame, detail_area, app);
+    draw_profile_selector(frame, selector, app, app.profile_cursor, true);
+    draw_usage_detail(frame, detail, app);
 }
 
 fn draw_usage_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {

--- a/tests/inline/tui_render_mod.rs
+++ b/tests/inline/tui_render_mod.rs
@@ -552,6 +552,219 @@ fn status_selected_row_tint_spans_both_lines() {
     );
 }
 
+// ── Narrow (phone-width) mode ────────────────────────────────────────────────
+// A Moshi-class terminal is ~45 columns. These tests pin the two halves of the
+// narrow contract: information survives at 45 cols (no truncation loss), and
+// the narrow paths are width-gated (desktop renders keep their side-by-side
+// shape). `╮╭` is the top-row junction two side-by-side boxes produce.
+
+/// A loaded app for the narrow sweeps: profiles + chain + incidents + tokens.
+fn narrow_app() -> App {
+    use crate::tokens::{ModelTokens, TokenStats};
+
+    let profiles = vec![
+        oauth("uwuclxdy", 42.0, 18.0, true),
+        oauth("work-account", 12.0, 3.0, false),
+    ];
+    let names: Vec<ProfileName> = profiles.iter().map(|p| p.name.clone()).collect();
+    let config = AppConfig {
+        state: AppState {
+            active_profile: Some("uwuclxdy".into()),
+            profiles: names,
+            fallback_chain: vec!["uwuclxdy".into(), "work-account".into()],
+            ..AppState::default()
+        },
+        profiles,
+    };
+    let mut app = App::new(config);
+    app.status.incidents = demo_incidents();
+    app.token_stats = Some(TokenStats {
+        models: vec![
+            ModelTokens {
+                model: "claude-opus-4-8".to_string(),
+                input: 10_000_000,
+                output: 800_000,
+                ..Default::default()
+            },
+            ModelTokens {
+                model: "claude-sonnet-5".to_string(),
+                input: 4_000_000,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    });
+    app
+}
+
+#[test]
+fn narrow_master_detail_stacks_wide_stays_side_by_side() {
+    let mut app = narrow_app();
+    for tab in [
+        Tab::Usage,
+        Tab::Setup,
+        Tab::Fallback,
+        Tab::Status,
+        Tab::Plugin,
+        Tab::Tokens,
+    ] {
+        app.tab = tab;
+        let narrow = dump(&app, 45, 38);
+        assert!(
+            !narrow.contains("╮╭"),
+            "{tab:?} still renders side-by-side boxes at 45 cols:\n{narrow}"
+        );
+        let wide = dump(&app, 100, 30);
+        assert!(
+            wide.contains("╮╭"),
+            "{tab:?} lost its desktop side-by-side layout at 100 cols:\n{wide}"
+        );
+    }
+}
+
+#[test]
+fn narrow_tokens_dashboard_keeps_card_text_whole() {
+    let mut app = narrow_app();
+    app.tab = Tab::Tokens;
+    let out = dump(&app, 45, 44);
+    for needle in [
+        "idle so far today",
+        "cache hit",
+        "COMPOSITION",
+        "cache read",
+    ] {
+        assert!(
+            out.contains(needle),
+            "`{needle}` truncated away at 45 cols:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn narrow_overview_chain_row_keeps_its_figures_on_one_line() {
+    let mut app = narrow_app();
+    app.tab = Tab::Overview;
+    let out = dump(&app, 45, 38);
+    let row = out
+        .lines()
+        .find(|l| l.contains("1 uwuclxdy"))
+        .unwrap_or_else(|| panic!("chain row missing:\n{out}"));
+    assert!(
+        row.contains("42") && row.contains("/ 80%"),
+        "chain figures wrapped off the row at 45 cols:\n{out}"
+    );
+
+    // Wide keeps the full 12-cell gauge; narrow shrinks it instead of wrapping.
+    let gauge_cells = |line: &str| line.chars().filter(|c| *c == '▰' || *c == '▱').count();
+    assert_eq!(
+        gauge_cells(row),
+        10,
+        "narrow gauge sized from leftover width"
+    );
+    let wide = dump(&app, 90, 24);
+    let wide_row = wide
+        .lines()
+        .find(|l| l.contains("1 uwuclxdy"))
+        .unwrap_or_else(|| panic!("wide chain row missing:\n{wide}"));
+    assert_eq!(gauge_cells(wide_row), 12, "desktop gauge untouched");
+
+    // The 3-digit worst case (a 100% last-resort member) is exactly the row
+    // the old figure(4) budget overflowed by one column.
+    let mut maxed = narrow_app();
+    {
+        let mut cfg = maxed.config();
+        for p in cfg.profiles.iter_mut() {
+            p.fallback_threshold = Some(100.0);
+        }
+    }
+    maxed.tab = Tab::Overview;
+    let out = dump(&maxed, 45, 38);
+    let row = out
+        .lines()
+        .find(|l| l.contains("1 uwuclxdy"))
+        .unwrap_or_else(|| panic!("100%-threshold chain row missing:\n{out}"));
+    assert!(
+        row.contains("/ 100%"),
+        "3-digit threshold wrapped off the row at 45 cols:\n{out}"
+    );
+}
+
+#[test]
+fn narrow_footer_degrades_to_essential_hints() {
+    let mut app = narrow_app();
+    app.tab = Tab::Usage;
+    let out = dump(&app, 45, 38);
+    for needle in ["←→ tabs", "? help", "q quit"] {
+        assert!(
+            out.contains(needle),
+            "essential hint `{needle}` missing at 45 cols:\n{out}"
+        );
+    }
+    assert!(
+        !out.contains("refresh account"),
+        "non-essential hint should be dropped at 45 cols:\n{out}"
+    );
+    let wide = dump(&app, 120, 30);
+    assert!(
+        wide.contains("refresh account"),
+        "desktop keeps the full hint set:\n{wide}"
+    );
+}
+
+#[test]
+fn narrow_header_hides_the_gauge_without_a_dangling_separator() {
+    let mut app = narrow_app();
+    app.tab = Tab::Usage;
+    let narrow = dump(&app, 45, 38);
+    let row = narrow
+        .lines()
+        .find(|l| l.contains("accounts"))
+        .unwrap_or_else(|| panic!("header count row missing:\n{narrow}"));
+    assert!(
+        !row.contains('·'),
+        "hidden gauge left a dangling separator:\n{row}"
+    );
+    let wide = dump(&app, 120, 30);
+    let wide_row = wide
+        .lines()
+        .find(|l| l.contains("accounts"))
+        .unwrap_or_else(|| panic!("wide header count row missing:\n{wide}"));
+    assert!(
+        wide_row.contains('·'),
+        "desktop separator + gauge unchanged:\n{wide_row}"
+    );
+}
+
+#[test]
+fn narrow_status_detail_duration_drops_to_its_own_line() {
+    let mut app = narrow_app();
+    app.tab = Tab::Status;
+    let out = dump(&app, 45, 38);
+    // The duration must sit on its OWN line (bordered, otherwise empty), not
+    // glued to the age at the end of the pill row.
+    assert!(
+        out.lines().any(|l| l.trim_matches([' ', '│']) == "ongoing"),
+        "duration is not on its own line at 45 cols:\n{out}"
+    );
+}
+
+#[test]
+fn narrow_modal_body_wraps_instead_of_clipping() {
+    use crate::tui::app::{ConfirmAction, ConfirmState, Modal};
+    let mut app = narrow_app();
+    app.modals.push(Modal::Confirm(ConfirmState {
+        message: "switch every profile to a freshly rotated credential set immediately".into(),
+        detail: None,
+        choice: false,
+        on_confirm: ConfirmAction::RotateAll,
+    }));
+    let out = dump(&app, 45, 38);
+    assert!(
+        out.contains("immediately"),
+        "modal body clipped its tail at 45 cols:\n{out}"
+    );
+}
+
 #[test]
 fn empty_state_renders() {
     let config = AppConfig {

--- a/tests/inline/tui_render_overview.rs
+++ b/tests/inline/tui_render_overview.rs
@@ -596,7 +596,7 @@ fn chain_row_switch_hint_rides_the_target_row() {
     let config = config_with(vec![a], Some("a"), vec!["a"]);
     let app = App::new(config);
     let cfg = app.config();
-    let row = chain_row(&cfg, "a", 0, 0, 8, 3, None, Some(7200));
+    let row = chain_row(&cfg, "a", 0, 0, 8, GAUGE_W, 3, None, Some(7200));
     let base = row.base_width();
     let line = row.into_line(base + TRAILER_GAP, 60);
     let text = line_text(&line);
@@ -699,6 +699,7 @@ fn chain_row_shows_both_switch_hint_and_reason_marker_when_they_fit() {
         0,
         0,
         8,
+        GAUGE_W,
         3,
         Some(BlockedReason::AuthBroken),
         Some(7200),
@@ -728,6 +729,7 @@ fn chain_row_drops_switch_hint_before_reason_marker_when_narrow() {
             0,
             0,
             8,
+            GAUGE_W,
             3,
             Some(BlockedReason::AuthBroken),
             Some(7200),


### PR DESCRIPTION
Closes #48.

One breakpoint (`panes::NARROW_BODY_W = 60`, measured against the body width each frame) gates every change — **at or above it every rendering is byte-identical to today**, and the tests pin both halves of that contract (content survives at 45 cols; the desktop keeps its side-by-side shape at ≥60).

> **Disclosure** (same as #45): implemented with an LLM (Claude) driving under my direction; every frame below was rendered through the existing `TestBackend` harness and read by eye at 45×38 before/after, and the full suite + clippy + fmt ran green on this branch against `mommy`.

## What changes at < 60 cols

- **`panes::master_detail`** — new shared split for the five master-detail tabs (usage / setup / fallback / status / plugin) and the tokens Models view: horizontal `selector | detail` on desktop, **stacked selector-above-detail** at narrow (selector sized to its item count, capped at 40% of the body). At 45 cols the old split left the detail pane ~13 usable cells; stacked, both panes get full-width lines.
- **Tokens dashboard** — the side-by-side card pairs stack full-width (the `TODAY` card alone needs ~20 content cells; pairs at 45 cols crushed both).
- **Overview fallback-chain rows** — the gauge is sized from what the line actually has left (exact span budget, including 3-digit thresholds and 10+-member indexes) instead of a fixed 12 cells, so the trailing `42 / 80%` no longer hard-wraps onto an orphan line.
- **Footer** — measured degradation: while the row overflows, drop the rightmost non-essential hint; `←→ tabs`, `? help`, `q`/`esc`, and armed confirms always survive. (This also fixes a pre-existing clip at plain 80-col terminals, where the tokens tab's 86-col hint row lost `? help q quit` from the right edge.)
- **Header row 1** — the ` · ` separator now renders only when the gauge itself survives `gauge_fit` (budget math unchanged — the separator width is subtracted exactly as before, so fit decisions are bit-identical); previously a hidden gauge left a dangling `·`.
- **Status detail** — the right-aligned duration drops to its own line when there's no room to right-align, instead of gluing onto the age (`…2026-06-06ongoing`).
- **Modals** — a body line wider than the modal's inner width is pre-split into inner-width rows by character (`chunk_line`, span styles preserved), so the height math is exact by construction; anything that fits renders exactly as before. (Chose explicit pre-splitting over `Wrap {…}` because ratatui's word-wrap can use more rows than any cheap height estimate and silently clip the tail.)

## Before / after at 45×38 (TestBackend frames)

Usage tab, before — detail pane after chrome keeps ~13 cells:

```
╭ ACCOUNTS ────────╮╭ uwuclxdy ─────────────╮
│ ❯ uwuclxdy       ││ plan      oauth       │
│   work-account   ││ status    ↻ up to dat │
│                  ││ 5h            [██░░]  │
```

after — stacked, both panes full width:

```
╭ ACCOUNTS ─────────────────────────────────╮
│ ❯ uwuclxdy                                │
│   work-account                            │
╰───────────────────────────────────────────╯
╭ uwuclxdy ─────────────────────────────────╮
│ plan      oauth                [ active ] │
│ status    ↻ up to date                    │
│ 5h                                    42% │
│ █████████████████░░░░░░░░░░░░░░░░░░░░░░░░ │
```

Overview chain row, before → after:

```
│  ╭ 1 uwuclxdy      ▰▰▰▰▰▰▱▱▱▱▱▱   42 /    │
│ 80%                                       │
```
```
│  ╭ 1 uwuclxdy      ▰▰▰▰▰▰▱▱▱▱     42 / 80%│
```

Tokens dashboard cards, before (`idle so far tod`, `0% cache h`, crushed charts) → after (every card full-width and whole: `idle so far today`, `0% cache hit`, readable model bars and the 24-bucket hour chart).

## Tests

New in `tests/inline/tui_render_mod.rs` (all fail on `mommy` without this change):

- `narrow_master_detail_stacks_wide_stays_side_by_side` — no `╮╭` box junction at 45 for the six converted surfaces; junction present at 100.
- `narrow_tokens_dashboard_keeps_card_text_whole` — `idle so far today` / `cache hit` / `COMPOSITION` / `cache read` survive at 45.
- `narrow_overview_chain_row_keeps_its_figures_on_one_line` — figures stay on the row; gauge is 10 cells at 45 (leftover-width budget, incl. a `/ 100%` 3-digit case) and exactly 12 on desktop.
- `narrow_footer_degrades_to_essential_hints` — `←→ tabs` / `? help` / `q quit` survive at 45, `refresh account` dropped; full set intact at 120.
- `narrow_header_hides_the_gauge_without_a_dangling_separator` — no `·` on the count row at 45; separator + gauge unchanged at 120.
- `narrow_status_detail_duration_drops_to_its_own_line`, `narrow_modal_body_wraps_instead_of_clipping`.

`cargo test` 970 green on this branch, clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
