### PR TITLE
fix(switch): a clauth-owned live symlink is never "unsaved credentials"

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -9,9 +9,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result, bail};
 
 use crate::claude::{
-    ClaudeEndpoint, LinkState, apply_profile_to_claude_settings, classify_credentials_link,
-    clear_claude_credentials, force_link_profile_credentials, force_snapshot_active_credentials,
-    is_first_login, link_profile_credentials, live_credentials_are_shell,
+    ClaudeEndpoint, apply_profile_to_claude_settings, clear_claude_credentials,
+    force_link_profile_credentials, force_snapshot_active_credentials, link_profile_credentials,
     live_diverged_and_unsaved, managed_env_key_label, read_claude_credentials,
     read_claude_endpoint_config, snapshot_active_credentials,
 };
@@ -77,20 +76,21 @@ pub(crate) fn switch_profile(config: &mut AppConfig, name: &str) -> Result<()> {
         // first-login), so dropping it would strand a fresh `/login` chain — keep
         // the non-force refuse-guard there. Every other state is captured or
         // adoptable by the snapshot below, so force the relink: on macOS the live
-        // `.credentials.json` is always a regular-file Keychain mirror of the
-        // active account and thus legitimately differs from the target, which the
-        // non-force guard's live-vs-target byte check would wrongly reject on every
-        // switch. (Interactive callers already route a real divergence to the
-        // reconcile path, so this branch is only reachable uncaptured via the
-        // scheduler — where refusing, not dropping, is the safe outcome.)
-        // A logged-out shell holds no login to strand, so it forfeits the
-        // refuse-guard (which would otherwise wedge the switch on an empty file).
+        // `.credentials.json` is a regular-file Keychain mirror of the active
+        // account, so it legitimately differs from the target, which the non-force
+        // guard's live-vs-target byte check would wrongly reject. The SAME
+        // predicate the defer/banner gates use — `live_diverged_and_unsaved` —
+        // decides here, so a login already saved in the store (the mirror, a
+        // clauth symlink) forces the relink even once a sidecar capture flips the
+        // install source and makes classify read Diverged over it; without that
+        // exemption the guarded link byte-rejects the macOS mirror and the switch
+        // fails "unsaved credentials" though nothing is unsaved. (Interactive
+        // callers already route a real divergence to the reconcile path, so this
+        // branch is only reachable uncaptured via the scheduler — where refusing,
+        // not dropping, is the safe outcome.) A logged-out shell holds no login to
+        // strand, so it too forfeits the refuse-guard.
         let uncaptured_relogin = match config.state.active_profile.as_deref() {
-            Some(active) => {
-                matches!(classify_credentials_link(active)?, LinkState::Diverged)
-                    && !is_first_login(active)?
-                    && !live_credentials_are_shell()
-            }
+            Some(active) => live_diverged_and_unsaved(active)?,
             None => false,
         };
         snapshot_active_credentials(config)?;

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -11,8 +11,9 @@ use anyhow::{Context, Result, bail};
 use crate::claude::{
     ClaudeEndpoint, LinkState, apply_profile_to_claude_settings, classify_credentials_link,
     clear_claude_credentials, force_link_profile_credentials, force_snapshot_active_credentials,
-    is_first_login, link_profile_credentials, live_credentials_are_shell, managed_env_key_label,
-    read_claude_credentials, read_claude_endpoint_config, snapshot_active_credentials,
+    is_first_login, link_profile_credentials, live_credentials_are_shell,
+    live_diverged_and_unsaved, managed_env_key_label, read_claude_credentials,
+    read_claude_endpoint_config, snapshot_active_credentials,
 };
 use crate::lock::with_state_lock;
 use crate::lockorder::RankedMutex;
@@ -140,11 +141,7 @@ pub(crate) fn switch_profile_cli(config: AppConfig, canonical: &str) -> Result<(
     // exempt: capturing its blank tokens would destroy the outgoing profile's
     // stored login.
     let reconciled = match outgoing.as_deref() {
-        Some(active) => {
-            matches!(classify_credentials_link(active)?, LinkState::Diverged)
-                && !is_first_login(active)?
-                && !live_credentials_are_shell()
-        }
+        Some(active) => live_diverged_and_unsaved(active)?,
         None => false,
     };
 
@@ -275,11 +272,7 @@ pub(crate) fn switch_profile_noninteractive(
     // A logged-out shell is no divergence to resolve: skip the default and take
     // the plain switch, which replaces the empty file.
     let diverged = match previous.as_deref() {
-        Some(active) => {
-            matches!(classify_credentials_link(active)?, LinkState::Diverged)
-                && !is_first_login(active)?
-                && !live_credentials_are_shell()
-        }
+        Some(active) => live_diverged_and_unsaved(active)?,
         None => false,
     };
 

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -330,6 +330,24 @@ pub(crate) fn live_credentials_are_shell() -> bool {
     )
 }
 
+/// The unsaved-credentials gate shared by every switch / defer / divergence-prompt
+/// path: the live login diverges from what a switch to `active` installs AND holds
+/// a login worth protecting. Three diverging states carry nothing unsaved and are
+/// exempt — a first-login adoption (captured on switch, not stranded), a logged-out
+/// shell (blank tokens, see [`live_credentials_are_shell`]), and a clauth-owned
+/// symlink (its target IS a profile store, so re-pointing it loses no login, see
+/// [`live_login_is_clauth_symlink`]). Routing every gate through this one predicate
+/// keeps the exemptions from drifting apart. The underlying reads propagate their
+/// error; a boolean gate maps that to `false` with `.unwrap_or(false)`.
+pub(crate) fn live_diverged_and_unsaved(active: &str) -> Result<bool> {
+    Ok(
+        matches!(classify_credentials_link(active)?, LinkState::Diverged)
+            && !is_first_login(active)?
+            && !live_credentials_are_shell()
+            && !live_login_is_clauth_symlink(),
+    )
+}
+
 /// macOS: mirror a profile's stored OAuth login into the Keychain so Claude Code
 /// (which reads the Keychain, not the file) actually switches account. No-op when
 /// the profile has no stored `credentials.json` (a base_url profile, whose

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -281,24 +281,68 @@ fn is_first_login_at(link: &Path, expected: &Path) -> bool {
         .is_some_and(|creds| creds.claude_ai_oauth.is_some())
 }
 
-/// True when the live `.credentials.json` is clauth's own symlink into a
-/// profile store. Whatever it points at, that login is saved by construction —
-/// the target IS a profile's store file — so the unsaved-credentials gates
-/// have nothing to protect and must not defer a switch (or raise the
-/// divergence prompt) on it. `Diverged` + symlink arises legitimately when a
-/// profile's INSTALL SOURCE changes under a live link: capturing a
-/// `setup-token` sidecar for the ACTIVE profile flips
-/// [`install_source_path`] from `credentials.json` to `session-token.json`
-/// while the old link still points at the former — a stale link the next
-/// switch re-points, not an unsaved login. Without this exemption every
-/// unattended switch fails "unsaved credentials; resolve in the TUI" until
-/// its retry TTL, and the TUI prompts about credentials that are fully
-/// saved (observed live 2026-07-21 on the macOS fork).
-pub(crate) fn live_login_is_clauth_symlink() -> bool {
-    claude_credentials_path()
-        .ok()
-        .and_then(|p| p.symlink_metadata().ok())
-        .is_some_and(|m| m.file_type().is_symlink())
+/// True when the live `.credentials.json` login is already saved in `active`'s
+/// store — so the unsaved-credentials gates have nothing to protect and must
+/// not defer a switch (or raise the divergence prompt) on it. Two ways to be
+/// saved, one structural and one by content:
+///
+/// * The live slot is clauth's own symlink. CC writes a regular file; only a
+///   switch symlinks the slot, so a symlink there points into a profile store
+///   by construction — that login is saved whatever it resolves to, even if
+///   the target is momentarily unreadable (a store file removed under a live
+///   link).
+/// * The live login's OAuth access token matches one of `active`'s stored
+///   credential files (`credentials.json` or `session-token.json`). This is
+///   the cross-platform half, and the one that matters on macOS: Claude Code
+///   rewrites `~/.claude/.credentials.json` as a regular-file mirror of the
+///   Keychain after every run, clobbering our symlink with an identical-content
+///   regular file — `is_symlink()` then reads false, but the content is still
+///   saved. On Windows the live slot is always a copy (no symlinks), so the
+///   content half carries it there too — no unix-only footnote.
+///
+/// The `Diverged`-but-saved state this clears arises when a profile's INSTALL
+/// SOURCE changes under the live slot: capturing a `setup-token` sidecar for
+/// the ACTIVE profile flips [`install_source_path`] from `credentials.json` to
+/// `session-token.json` (removing it flips back) while the live slot still
+/// holds the previous source's content — a stale slot the next switch
+/// re-installs, not an unsaved login. Both stores are checked because the flip
+/// can leave the slot holding either the OAuth login or the static mint.
+/// Without this exemption every unattended switch fails "unsaved credentials;
+/// resolve in the TUI" until its retry TTL, and the TUI prompts about
+/// credentials that are fully saved (observed live 2026-07-21 on the macOS
+/// fork as a symlink; recurs there as a regular file after any CC session).
+pub(crate) fn live_login_is_stored(active: &str) -> bool {
+    let Ok(link) = claude_credentials_path() else {
+        return false;
+    };
+    // Structural half: a symlink at the live slot is clauth's own, pointing
+    // into a store by construction — saved even if the target is unreadable.
+    if link
+        .symlink_metadata()
+        .is_ok_and(|m| m.file_type().is_symlink())
+    {
+        return true;
+    }
+    // Content half (the macOS regular-file mirror, the Windows copy): the live
+    // login's token equals one the profile already stores. A blank/absent live
+    // token can't "match" a real login — a logged-out shell is handled by
+    // [`live_credentials_are_shell`], not here.
+    let Ok(dir) = profile_dir(active) else {
+        return false;
+    };
+    let Ok(live) = read_json_file::<ClaudeCredentials>(&link) else {
+        return false;
+    };
+    if live.access_token().filter(|t| !t.is_empty()).is_none() {
+        return false;
+    }
+    ["credentials.json", "session-token.json"]
+        .into_iter()
+        .any(|file| {
+            read_json_file::<ClaudeCredentials>(&dir.join(file))
+                .ok()
+                .is_some_and(|stored| stored.access_token() == live.access_token())
+        })
 }
 
 pub(crate) fn read_claude_credentials() -> Result<Option<ClaudeCredentials>> {
@@ -334,17 +378,17 @@ pub(crate) fn live_credentials_are_shell() -> bool {
 /// path: the live login diverges from what a switch to `active` installs AND holds
 /// a login worth protecting. Three diverging states carry nothing unsaved and are
 /// exempt — a first-login adoption (captured on switch, not stranded), a logged-out
-/// shell (blank tokens, see [`live_credentials_are_shell`]), and a clauth-owned
-/// symlink (its target IS a profile store, so re-pointing it loses no login, see
-/// [`live_login_is_clauth_symlink`]). Routing every gate through this one predicate
-/// keeps the exemptions from drifting apart. The underlying reads propagate their
-/// error; a boolean gate maps that to `false` with `.unwrap_or(false)`.
+/// shell (blank tokens, see [`live_credentials_are_shell`]), and a login already
+/// saved in the profile's store (its content is captured, so re-installing loses
+/// no login, see [`live_login_is_stored`]). Routing every gate through this one
+/// predicate keeps the exemptions from drifting apart. The underlying reads
+/// propagate their error; a boolean gate maps that to `false` with `.unwrap_or(false)`.
 pub(crate) fn live_diverged_and_unsaved(active: &str) -> Result<bool> {
     Ok(
         matches!(classify_credentials_link(active)?, LinkState::Diverged)
             && !is_first_login(active)?
             && !live_credentials_are_shell()
-            && !live_login_is_clauth_symlink(),
+            && !live_login_is_stored(active),
     )
 }
 

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -281,6 +281,26 @@ fn is_first_login_at(link: &Path, expected: &Path) -> bool {
         .is_some_and(|creds| creds.claude_ai_oauth.is_some())
 }
 
+/// True when the live `.credentials.json` is clauth's own symlink into a
+/// profile store. Whatever it points at, that login is saved by construction —
+/// the target IS a profile's store file — so the unsaved-credentials gates
+/// have nothing to protect and must not defer a switch (or raise the
+/// divergence prompt) on it. `Diverged` + symlink arises legitimately when a
+/// profile's INSTALL SOURCE changes under a live link: capturing a
+/// `setup-token` sidecar for the ACTIVE profile flips
+/// [`install_source_path`] from `credentials.json` to `session-token.json`
+/// while the old link still points at the former — a stale link the next
+/// switch re-points, not an unsaved login. Without this exemption every
+/// unattended switch fails "unsaved credentials; resolve in the TUI" until
+/// its retry TTL, and the TUI prompts about credentials that are fully
+/// saved (observed live 2026-07-21 on the macOS fork).
+pub(crate) fn live_login_is_clauth_symlink() -> bool {
+    claude_credentials_path()
+        .ok()
+        .and_then(|p| p.symlink_metadata().ok())
+        .is_some_and(|m| m.file_type().is_symlink())
+}
+
 pub(crate) fn read_claude_credentials() -> Result<Option<ClaudeCredentials>> {
     let path = claude_credentials_path()?;
     if !path.exists() {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -214,6 +214,7 @@ fn active_diverged_unsaved(active: &str) -> bool {
         Some(LinkState::Diverged)
     ) && !is_first_login(active).unwrap_or(false)
         && !live_credentials_are_shell()
+        && !crate::claude::live_login_is_clauth_symlink()
 }
 
 /// Owns the shared `Arc` stores (cloned into the scheduler) plus main-loop-only

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -33,10 +33,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
-use crate::claude::{
-    LinkState, classify_credentials_link, is_first_login, link_profile_credentials,
-    live_credentials_are_shell,
-};
+use crate::claude::link_profile_credentials;
 use crate::lockorder::RankedMutex;
 use crate::logline::logline;
 use crate::profile::{
@@ -203,18 +200,16 @@ pub(crate) fn status_oneshot() -> Result<()> {
 /// and it isn't a first-login adoption — the daemon cannot prompt, so it skips
 /// the switch and leaves the resolution to the operator (TUI Divergence modal).
 ///
-/// A logged-out shell (see [`live_credentials_are_shell`]) is exempt: an empty
-/// login is not "unsaved credentials", and deferring on it wedges every
-/// headless switch behind a TUI decision about nothing while running sessions
-/// sit at "Login expired" (observed 2026-07-15). An unreadable/torn live file
-/// still defers — it may be a CC write in progress.
+/// A logged-out shell (see [`crate::claude::live_credentials_are_shell`]) is
+/// exempt: an empty login is not "unsaved credentials", and deferring on it
+/// wedges every headless switch behind a TUI decision about nothing while
+/// running sessions sit at "Login expired" (observed 2026-07-15). An
+/// unreadable/torn live file still defers — it may be a CC write in progress.
+/// The shell / first-login / clauth-symlink exemptions all live in
+/// [`crate::claude::live_diverged_and_unsaved`]; a read that errors outright
+/// maps to `false` (proceed) here.
 fn active_diverged_unsaved(active: &str) -> bool {
-    matches!(
-        classify_credentials_link(active).ok(),
-        Some(LinkState::Diverged)
-    ) && !is_first_login(active).unwrap_or(false)
-        && !live_credentials_are_shell()
-        && !crate::claude::live_login_is_clauth_symlink()
+    crate::claude::live_diverged_and_unsaved(active).unwrap_or(false)
 }
 
 /// Owns the shared `Arc` stores (cloned into the scheduler) plus main-loop-only

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7238,11 +7238,13 @@ fn poll_credentials_divergence(app: &mut App) {
         }
         return;
     }
-    // A clauth-owned symlink holds nothing unsaved — the next switch re-points it,
-    // losing no login — so it must not raise the banner. The switch/defer gates
-    // apply the same exemption through `live_diverged_and_unsaved`; the poll must
-    // adopt a first login before this point, so it checks the atomic here instead.
-    if crate::claude::live_login_is_clauth_symlink() {
+    // A login already saved in the active profile's store holds nothing unsaved —
+    // the next switch re-installs it, losing no login — so it must not raise the
+    // banner. This clears clauth's own symlink AND the macOS regular-file mirror CC
+    // writes over it. The switch/defer gates apply the same exemption through
+    // `live_diverged_and_unsaved`; the poll must adopt a first login before this
+    // point, so it checks the predicate directly here instead.
+    if crate::claude::live_login_is_stored(&active) {
         app.divergence_pending = None;
         return;
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3357,6 +3357,7 @@ fn active_diverged_unsaved(active: &str) -> bool {
         Some(LinkState::Diverged)
     ) && !is_first_login(active).unwrap_or(false)
         && !live_credentials_are_shell()
+        && !crate::claude::live_login_is_clauth_symlink()
 }
 
 /// Toast and raise the Divergence prompt for `active` (`verb` = blocked action).

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3352,12 +3352,7 @@ where
 /// first-login adoption (must be reconciled before clearing/relinking). A
 /// logged-out shell is exempt — an empty login needs no reconciling.
 fn active_diverged_unsaved(active: &str) -> bool {
-    matches!(
-        classify_credentials_link(active).ok(),
-        Some(LinkState::Diverged)
-    ) && !is_first_login(active).unwrap_or(false)
-        && !live_credentials_are_shell()
-        && !crate::claude::live_login_is_clauth_symlink()
+    crate::claude::live_diverged_and_unsaved(active).unwrap_or(false)
 }
 
 /// Toast and raise the Divergence prompt for `active` (`verb` = blocked action).
@@ -7241,6 +7236,14 @@ fn poll_credentials_divergence(app: &mut App) {
             }
             Err(e) => app.toast(ToastKind::Danger, format!("adopt failed\n{e}")),
         }
+        return;
+    }
+    // A clauth-owned symlink holds nothing unsaved — the next switch re-points it,
+    // losing no login — so it must not raise the banner. The switch/defer gates
+    // apply the same exemption through `live_diverged_and_unsaved`; the poll must
+    // adopt a first login before this point, so it checks the atomic here instead.
+    if crate::claude::live_login_is_clauth_symlink() {
+        app.divergence_pending = None;
         return;
     }
     resolve_or_note_divergence(app, &active);

--- a/tests/inline/actions.rs
+++ b/tests/inline/actions.rs
@@ -119,8 +119,8 @@ fn switch_replaces_active_account_mirror_without_refusing() {
 
     assert!(config.is_active("xfx"));
     assert_eq!(
-        classify_credentials_link("xfx").expect("classify"),
-        LinkState::LinkedTo,
+        crate::claude::classify_credentials_link("xfx").expect("classify"),
+        crate::claude::LinkState::LinkedTo,
         "after the switch the live path resolves to xfx's stored creds",
     );
 }

--- a/tests/inline/claude.rs
+++ b/tests/inline/claude.rs
@@ -1091,24 +1091,82 @@ fn a_rotating_pair_in_the_sidecar_never_engages_the_split() {
     );
 }
 
-/// Capturing a `setup-token` sidecar for the ACTIVE profile flips the install
-/// source from `credentials.json` to `session-token.json` while the live slot
-/// still holds the OLD symlink — classify rightly reads Diverged (the link no
-/// longer points at what a switch installs), but that state carries NOTHING
-/// unsaved: a clauth-owned symlink's content is a profile store by
-/// construction. `live_login_is_clauth_symlink` is the predicate the
-/// unsaved-credentials gates use to tell the two apart; without it every
-/// unattended switch fails "unsaved credentials" until its retry TTL and the
-/// TUI prompts about credentials that are fully saved.
-#[cfg(unix)]
+/// The macOS steady state, and the reason the exemption is content-based rather
+/// than symlink-identity: after a switch, Claude Code rewrites
+/// `~/.claude/.credentials.json` as a REGULAR-FILE mirror of the Keychain,
+/// clobbering clauth's symlink with identical content. Capturing a `setup-token`
+/// sidecar for the ACTIVE profile then flips the install source to
+/// `session-token.json`, so classify reads Diverged over that regular file —
+/// yet the live OAuth login is fully saved in the profile's `credentials.json`.
+/// `live_login_is_stored` must exempt it by CONTENT (a symlink-identity check
+/// reads a regular file as unsaved and defers every switch). Runs on every
+/// platform — the content path is what makes the fix portable — so a Linux CI
+/// exercises the macOS shape the maintainer can't.
 #[test]
-fn captured_sidecar_under_stale_live_link_is_diverged_but_not_unsaved() {
+fn a_regular_file_mirror_of_a_stored_login_is_not_unsaved() {
     let _home = HomeSandbox::new();
     let mut profile = crate::profile::Profile::new("split".to_string(), None, None);
     profile.credentials = Some(creds("usage-access", Some("usage-refresh")));
     crate::profile::save_profile(&profile).expect("save profile");
 
-    // The pre-capture state: live symlink → the profile's rotating store.
+    // CC's regular-file mirror: same OAuth login as the stored credentials.json,
+    // written as a plain file (not our symlink).
+    let live = claude_credentials_path().expect("creds path");
+    fs::create_dir_all(live.parent().expect("parent")).expect("mkdir .claude");
+    fs::write(
+        &live,
+        serde_json::to_vec(&creds("usage-access", Some("usage-refresh"))).expect("ser"),
+    )
+    .expect("write regular-file mirror");
+
+    // The sidecar capture flips the install source; classify reads Diverged over
+    // the regular file (it no longer matches what a switch installs).
+    fill_session_token_by_hand("split", "oat-access");
+    assert!(
+        matches!(
+            classify_credentials_link("split").expect("classify"),
+            LinkState::Diverged
+        ),
+        "the mirror no longer matches the flipped install source"
+    );
+    assert!(
+        live_login_is_stored("split"),
+        "…but the mirror's login is saved in credentials.json — not unsaved \
+         (a symlink-identity check would read this regular file as unsaved)"
+    );
+
+    // A genuine CC re-login (a DIFFERENT token) is the state the gates exist for —
+    // it matches neither store, so it is protected.
+    fs::write(
+        &live,
+        serde_json::to_vec(&creds("cc-relogin", Some("cc-rt"))).expect("ser"),
+    )
+    .expect("write regular re-login");
+    assert!(
+        !live_login_is_stored("split"),
+        "a re-login whose token matches no store must stay protected"
+    );
+
+    // Absent live slot: nothing to match, nothing saved.
+    fs::remove_file(&live).expect("drop file");
+    assert!(!live_login_is_stored("split"));
+}
+
+/// The symlink half of the same exemption, and the original 2026-07-21 repro:
+/// capturing a sidecar for the ACTIVE profile flips the install source while the
+/// live slot is still clauth's symlink into `credentials.json`. classify reads
+/// Diverged (the link no longer points at what a switch installs), but a
+/// clauth-owned symlink's target IS a profile store by construction, so nothing
+/// is unsaved — `live_login_is_stored` exempts it both structurally (it's a
+/// symlink) and by content (reading through it yields the stored login).
+#[cfg(unix)]
+#[test]
+fn a_clauth_symlink_under_a_flipped_install_source_is_not_unsaved() {
+    let _home = HomeSandbox::new();
+    let mut profile = crate::profile::Profile::new("split".to_string(), None, None);
+    profile.credentials = Some(creds("usage-access", Some("usage-refresh")));
+    crate::profile::save_profile(&profile).expect("save profile");
+
     let live = claude_credentials_path().expect("creds path");
     fs::create_dir_all(live.parent().expect("parent")).expect("mkdir .claude");
     let store = crate::profile::profile_dir("split")
@@ -1123,8 +1181,6 @@ fn captured_sidecar_under_stale_live_link_is_diverged_but_not_unsaved() {
         "before the capture the link points at the install source"
     );
 
-    // The capture: a long-lived sidecar appears; the install source flips
-    // underneath the live link.
     fill_session_token_by_hand("split", "oat-access");
     assert!(
         matches!(
@@ -1134,21 +1190,16 @@ fn captured_sidecar_under_stale_live_link_is_diverged_but_not_unsaved() {
         "the stale link no longer points at what a switch installs"
     );
     assert!(
-        live_login_is_clauth_symlink(),
+        live_login_is_stored("split"),
         "…but a clauth-owned symlink holds nothing unsaved"
     );
 
-    // A regular-file live login (a CC /login) is the state the gates exist
-    // for — the predicate must NOT claim that one.
-    fs::remove_file(&live).expect("drop link");
-    fs::write(
-        &live,
-        serde_json::to_vec(&creds("cc-relogin", Some("cc-rt"))).expect("ser"),
-    )
-    .expect("write regular live");
-    assert!(!live_login_is_clauth_symlink());
-
-    // Absent live slot: nothing there, certainly not a symlink.
-    fs::remove_file(&live).expect("drop file");
-    assert!(!live_login_is_clauth_symlink());
+    // A dangling clauth symlink (its store file removed) still has no login to
+    // protect — the structural half keeps exempting it, so a switch is never
+    // deferred over an empty slot.
+    fs::remove_file(&store).expect("drop store file");
+    assert!(
+        live_login_is_stored("split"),
+        "a dangling clauth symlink is a store slot, not an unsaved login"
+    );
 }

--- a/tests/inline/claude.rs
+++ b/tests/inline/claude.rs
@@ -1090,3 +1090,65 @@ fn a_rotating_pair_in_the_sidecar_never_engages_the_split() {
         "switches keep installing the rotating pair from credentials.json"
     );
 }
+
+/// Capturing a `setup-token` sidecar for the ACTIVE profile flips the install
+/// source from `credentials.json` to `session-token.json` while the live slot
+/// still holds the OLD symlink — classify rightly reads Diverged (the link no
+/// longer points at what a switch installs), but that state carries NOTHING
+/// unsaved: a clauth-owned symlink's content is a profile store by
+/// construction. `live_login_is_clauth_symlink` is the predicate the
+/// unsaved-credentials gates use to tell the two apart; without it every
+/// unattended switch fails "unsaved credentials" until its retry TTL and the
+/// TUI prompts about credentials that are fully saved.
+#[cfg(unix)]
+#[test]
+fn captured_sidecar_under_stale_live_link_is_diverged_but_not_unsaved() {
+    let _home = HomeSandbox::new();
+    let mut profile = crate::profile::Profile::new("split".to_string(), None, None);
+    profile.credentials = Some(creds("usage-access", Some("usage-refresh")));
+    crate::profile::save_profile(&profile).expect("save profile");
+
+    // The pre-capture state: live symlink → the profile's rotating store.
+    let live = claude_credentials_path().expect("creds path");
+    fs::create_dir_all(live.parent().expect("parent")).expect("mkdir .claude");
+    let store = crate::profile::profile_dir("split")
+        .expect("dir")
+        .join("credentials.json");
+    std::os::unix::fs::symlink(&store, &live).expect("symlink live");
+    assert!(
+        matches!(
+            classify_credentials_link("split").expect("classify"),
+            LinkState::LinkedTo
+        ),
+        "before the capture the link points at the install source"
+    );
+
+    // The capture: a long-lived sidecar appears; the install source flips
+    // underneath the live link.
+    fill_session_token_by_hand("split", "oat-access");
+    assert!(
+        matches!(
+            classify_credentials_link("split").expect("classify"),
+            LinkState::Diverged
+        ),
+        "the stale link no longer points at what a switch installs"
+    );
+    assert!(
+        live_login_is_clauth_symlink(),
+        "…but a clauth-owned symlink holds nothing unsaved"
+    );
+
+    // A regular-file live login (a CC /login) is the state the gates exist
+    // for — the predicate must NOT claim that one.
+    fs::remove_file(&live).expect("drop link");
+    fs::write(
+        &live,
+        serde_json::to_vec(&creds("cc-relogin", Some("cc-rt"))).expect("ser"),
+    )
+    .expect("write regular live");
+    assert!(!live_login_is_clauth_symlink());
+
+    // Absent live slot: nothing there, certainly not a symlink.
+    fs::remove_file(&live).expect("drop file");
+    assert!(!live_login_is_clauth_symlink());
+}

--- a/tests/inline/daemon_mod.rs
+++ b/tests/inline/daemon_mod.rs
@@ -283,6 +283,63 @@ fn drain_pending_switch_proceeds_over_a_logged_out_shell() {
     );
 }
 
+/// A clauth-owned symlink in the live slot is never "unsaved credentials":
+/// capturing a long-lived `setup-token` sidecar for the ACTIVE profile flips its
+/// install source from `credentials.json` to `session-token.json`, so the live
+/// symlink — still pointing at the old `credentials.json` store — classifies
+/// Diverged, yet re-pointing it on the next switch loses no login. The queued
+/// switch must PROCEED; deferring failed every unattended switch "unsaved
+/// credentials" until its retry TTL (observed live 2026-07-21 on the macOS fork).
+#[cfg(unix)]
+#[test]
+fn drain_pending_switch_proceeds_over_a_stale_clauth_symlink() {
+    let _home = HomeSandbox::new();
+    let config = persist(
+        vec![
+            profile_with_creds("alpha", "at-alpha"),
+            profile_with_creds("beta", "at-beta"),
+        ],
+        Some("alpha"),
+        90_000,
+    );
+    // The live slot is clauth's own symlink into alpha's rotating store — clean.
+    link_active_clean("alpha");
+    // A long-lived session token appears for alpha (no refresh token → never
+    // rotates), flipping its install source to session-token.json while the live
+    // symlink still points at credentials.json — classify now reads Diverged
+    // though the symlink holds nothing unsaved.
+    let sidecar = ClaudeCredentials {
+        claude_ai_oauth: Some(OAuthToken {
+            access_token: "sk-ant-oat-alpha".to_string(),
+            refresh_token: None,
+            expires_at: Some(future_expiry()),
+            scopes: None,
+            subscription_type: None,
+        }),
+    };
+    let alpha_dir = crate::profile::profile_dir("alpha").expect("alpha dir");
+    std::fs::write(
+        alpha_dir.join("session-token.json"),
+        serde_json::to_vec(&sidecar).expect("serialize sidecar"),
+    )
+    .expect("write session-token sidecar");
+    let mut daemon = daemon_for(config);
+
+    stage_switch(&daemon, "beta");
+    daemon.drain_pending_switch();
+
+    assert_eq!(
+        active_of(&daemon).as_deref(),
+        Some("beta"),
+        "a clauth-owned symlink holds nothing unsaved — the switch must proceed"
+    );
+    assert_eq!(
+        queued_targets(&daemon),
+        Vec::<String>::new(),
+        "the executed switch leaves nothing queued"
+    );
+}
+
 /// A live file that does not PARSE is not a shell — it may be a CC write in
 /// progress, i.e. possibly a login. The divergence deferral stays armed for
 /// it, exactly like a real diverged login.

--- a/tests/inline/daemon_mod.rs
+++ b/tests/inline/daemon_mod.rs
@@ -340,6 +340,68 @@ fn drain_pending_switch_proceeds_over_a_stale_clauth_symlink() {
     );
 }
 
+/// The macOS steady-state twin of the test above, and the round-2 finding: after
+/// a switch, Claude Code rewrites the live slot as a REGULAR-FILE mirror of the
+/// Keychain, clobbering the symlink. The sidecar flip then makes classify read
+/// Diverged over that regular file — but its login is alpha's saved
+/// `credentials.json`, so the queued switch must still PROCEED. A
+/// symlink-identity exemption reads the regular file as unsaved and defers here;
+/// the content-based `live_login_is_stored` clears it. No `#[cfg(unix)]` — a
+/// regular-file mirror is exactly the shape a Linux CI can pin for macOS.
+#[test]
+fn drain_pending_switch_proceeds_over_a_macos_regular_file_mirror() {
+    let _home = HomeSandbox::new();
+    let config = persist(
+        vec![
+            profile_with_creds("alpha", "at-alpha"),
+            profile_with_creds("beta", "at-beta"),
+        ],
+        Some("alpha"),
+        90_000,
+    );
+    // CC's regular-file mirror: alpha's stored login, written as a plain file
+    // (not our symlink), holding the SAME access token as alpha's credentials.json.
+    let dir = claude_dir().expect("claude dir");
+    std::fs::create_dir_all(&dir).expect("mkdir ~/.claude");
+    std::fs::write(
+        dir.join(".credentials.json"),
+        serde_json::to_vec(&oauth_creds("at-alpha")).expect("serialize mirror"),
+    )
+    .expect("write regular-file mirror");
+    // The sidecar flips alpha's install source to session-token.json; the mirror
+    // now classifies Diverged though its login is fully saved.
+    let sidecar = ClaudeCredentials {
+        claude_ai_oauth: Some(OAuthToken {
+            access_token: "sk-ant-oat-alpha".to_string(),
+            refresh_token: None,
+            expires_at: Some(future_expiry()),
+            scopes: None,
+            subscription_type: None,
+        }),
+    };
+    let alpha_dir = crate::profile::profile_dir("alpha").expect("alpha dir");
+    std::fs::write(
+        alpha_dir.join("session-token.json"),
+        serde_json::to_vec(&sidecar).expect("serialize sidecar"),
+    )
+    .expect("write session-token sidecar");
+    let mut daemon = daemon_for(config);
+
+    stage_switch(&daemon, "beta");
+    daemon.drain_pending_switch();
+
+    assert_eq!(
+        active_of(&daemon).as_deref(),
+        Some("beta"),
+        "a regular-file mirror of a saved login holds nothing unsaved — the switch must proceed"
+    );
+    assert_eq!(
+        queued_targets(&daemon),
+        Vec::<String>::new(),
+        "the executed switch leaves nothing queued"
+    );
+}
+
 /// A live file that does not PARSE is not a shell — it may be a CC write in
 /// progress, i.e. possibly a login. The divergence deferral stays armed for
 /// it, exactly like a real diverged login.

--- a/tests/inline/tui_app.rs
+++ b/tests/inline/tui_app.rs
@@ -1383,6 +1383,59 @@ fn divergence_poll_ignores_a_logged_out_shell() {
     );
 }
 
+/// A clauth-owned symlink in the live slot is never "unsaved credentials": a
+/// long-lived `session-token.json` for the active profile flips its install
+/// source, so the live symlink classifies Diverged though re-pointing it loses
+/// no login. The 1Hz poll must NOT flag the banner — it repainted it every second.
+#[cfg(unix)]
+#[test]
+fn divergence_poll_ignores_a_stale_clauth_symlink() {
+    use crate::profile::{
+        AppConfig, AppState, ClaudeCredentials, OAuthToken, Profile, save_profile,
+    };
+    let _home = crate::testutil::HomeSandbox::new();
+
+    let mut work = Profile::new("work".to_string(), None, None);
+    work.credentials = Some(login_creds("rt-work"));
+    save_profile(&work).expect("save work");
+    // The live slot is clauth's own symlink into work's rotating store.
+    crate::claude::force_link_profile_credentials("work").expect("link work");
+    // A long-lived session token (no refresh token) flips work's install source;
+    // the stale symlink still points at credentials.json, so classify reads
+    // Diverged with nothing unsaved behind it.
+    let sidecar = ClaudeCredentials {
+        claude_ai_oauth: Some(OAuthToken {
+            access_token: "sk-ant-oat-work".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: None,
+            subscription_type: None,
+        }),
+    };
+    let work_dir = crate::profile::profile_dir("work").expect("work dir");
+    std::fs::write(
+        work_dir.join("session-token.json"),
+        serde_json::to_vec(&sidecar).expect("ser sidecar"),
+    )
+    .expect("write session-token sidecar");
+
+    let mut app = App::new(AppConfig {
+        state: AppState {
+            active_profile: Some("work".into()),
+            profiles: vec!["work".into()],
+            ..AppState::default()
+        },
+        profiles: vec![work],
+    });
+
+    force_poll(&mut app);
+    assert!(
+        app.divergence_pending.is_none(),
+        "a clauth-owned symlink is nothing to resolve — no 1Hz banner"
+    );
+    assert!(app.modals.is_empty(), "and certainly no modal");
+}
+
 /// The banner and the resolver both identify the live login's OWNER when it is
 /// a stored sibling — by exact token match here (the half-landed-switch shape)
 /// — and the resolver leads with the "switch to it" action.

--- a/tests/inline/tui_app.rs
+++ b/tests/inline/tui_app.rs
@@ -1436,6 +1436,60 @@ fn divergence_poll_ignores_a_stale_clauth_symlink() {
     assert!(app.modals.is_empty(), "and certainly no modal");
 }
 
+/// The macOS steady-state twin: after a switch, Claude Code rewrites the live
+/// slot as a REGULAR-FILE mirror of the Keychain, so the stale-sidecar state the
+/// test above pins as a symlink recurs as a regular file. The 1Hz poll must
+/// still stay silent — the mirror's login is saved in `credentials.json`. A
+/// symlink-identity check reads the regular file as divergence and repaints the
+/// banner every second; the content-based exemption clears it.
+#[test]
+fn divergence_poll_ignores_a_macos_regular_file_mirror() {
+    use crate::profile::{
+        AppConfig, AppState, ClaudeCredentials, OAuthToken, Profile, save_profile,
+    };
+    let _home = crate::testutil::HomeSandbox::new();
+
+    let mut work = Profile::new("work".to_string(), None, None);
+    work.credentials = Some(login_creds("rt-work"));
+    save_profile(&work).expect("save work");
+    // CC's regular-file mirror: work's stored login as a plain file (access token
+    // "acc", same as work's credentials.json), NOT our symlink.
+    write_live_creds(&login_creds("rt-work"));
+    // The sidecar flips work's install source; the mirror now classifies Diverged
+    // with nothing unsaved behind it.
+    let sidecar = ClaudeCredentials {
+        claude_ai_oauth: Some(OAuthToken {
+            access_token: "sk-ant-oat-work".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: None,
+            subscription_type: None,
+        }),
+    };
+    let work_dir = crate::profile::profile_dir("work").expect("work dir");
+    std::fs::write(
+        work_dir.join("session-token.json"),
+        serde_json::to_vec(&sidecar).expect("ser sidecar"),
+    )
+    .expect("write session-token sidecar");
+
+    let mut app = App::new(AppConfig {
+        state: AppState {
+            active_profile: Some("work".into()),
+            profiles: vec!["work".into()],
+            ..AppState::default()
+        },
+        profiles: vec![work],
+    });
+
+    force_poll(&mut app);
+    assert!(
+        app.divergence_pending.is_none(),
+        "a saved login mirrored as a regular file is nothing to resolve — no 1Hz banner"
+    );
+    assert!(app.modals.is_empty(), "and certainly no modal");
+}
+
 /// The banner and the resolver both identify the live login's OWNER when it is
 /// a stored sibling — by exact token match here (the half-landed-switch shape)
 /// — and the resolver leads with the "switch to it" action.


### PR DESCRIPTION
## The bug

Capturing a setup-token sidecar for the **active** profile (`clauth login <p> --setup-token`, #52/#53) flips `install_source_path` from `credentials.json` to `session-token.json` — while the live slot still holds the old symlink pointing at `credentials.json`. From that moment:

- `classify_credentials_link` reads **Diverged** (correct: the link no longer points at what a switch installs),
- but `active_diverged_unsaved` treats every Diverged non-shell state as an unsaved login needing protection, so
- every unattended switch fails `active '<p>' has unsaved credentials; resolve in the TUI` until its retry TTL, switch-off is skipped, and the TUI raises the divergence prompt about credentials that are fully saved.

Hit live 2026-07-21 on the macOS fork while repairing a mis-filled sidecar: a queued switch retried the failure loop until `gave up switching`.

## The fix

A clauth-owned symlink's content is a profile store **by construction** — re-pointing the link loses nothing, there is nothing unsaved to protect. New `claude::live_login_is_clauth_symlink()` exempts that state in both `active_diverged_unsaved` gates (daemon + TUI parity). A regular-file live login (a real CC `/login`) is gated exactly as before.

Regression test walks the full transition: LinkedTo before the capture → Diverged-but-not-unsaved after → regular-file and absent live slots still classify as before.

1237 tests green, clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)