### PR TITLE
fix(credentials): preserve mcpOAuth blocks across a profile switch

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -432,6 +432,48 @@ pub(crate) fn create_symlink(target: &Path, link: &Path) -> Result<()> {
         .context("failed to copy credentials")
 }
 
+/// Carry the live credential's non-login blocks — notably `mcpOAuth`, the
+/// per-MCP-server logins Claude Code keeps alongside the Claude account — onto
+/// `target` before it becomes the live credential. These blocks are independent
+/// of which Claude account is active, so an account switch must preserve them:
+/// without this, switching to a profile whose store lacks them (e.g. a fresh
+/// browser login) drops every MCP-server auth. Each non-login top-level block
+/// present in the live file is copied onto the target (its prior copy of that
+/// block overwritten); a block the live file lacks is left as the target has it.
+/// The target's `claudeAiOauth` login is never touched. A no-op when the live
+/// file is unreadable, carries no such blocks, or `target` is not an OAuth store
+/// (a session-token sidecar has no `claudeAiOauth`).
+fn carry_live_extra_into(link: &Path, target: &Path) -> Result<()> {
+    let Ok(live) = read_json_file::<serde_json::Value>(link) else {
+        return Ok(());
+    };
+    let Ok(mut stored) = read_json_file::<serde_json::Value>(target) else {
+        return Ok(());
+    };
+    let (Some(live_obj), Some(stored_obj)) = (live.as_object(), stored.as_object_mut()) else {
+        return Ok(());
+    };
+    // Only an OAuth store carries these blocks; never touch a session-token sidecar.
+    if !stored_obj.contains_key("claudeAiOauth") {
+        return Ok(());
+    }
+    let mut changed = false;
+    for (key, value) in live_obj {
+        if key == "claudeAiOauth" {
+            continue;
+        }
+        if stored_obj.get(key) != Some(value) {
+            stored_obj.insert(key.clone(), value.clone());
+            changed = true;
+        }
+    }
+    if changed {
+        atomic_write_600(target, serde_json::to_string_pretty(&stored)?)
+            .context("failed to carry mcpOAuth into profile credentials")?;
+    }
+    Ok(())
+}
+
 /// Symlink `~/.claude/.credentials.json` → profile's `credentials.json` (copy on
 /// Windows). Refuses to overwrite a non-matching regular file — that would silently
 /// drop a CC re-login the user hasn't resolved yet.
@@ -442,15 +484,30 @@ pub(crate) fn link_profile_credentials(name: &str) -> Result<()> {
 
         if let Ok(meta) = link.symlink_metadata() {
             if !meta.file_type().is_symlink() {
-                let live_bytes = std::fs::read(&link).ok();
-                let target_bytes = std::fs::read(&target).ok();
-                if live_bytes != target_bytes {
+                // Compare the LOGIN only, not the whole file: mcpOAuth and other
+                // non-login blocks are carried across below (`carry_live_extra_into`),
+                // so a live file that differs from the profile only in those must
+                // not read as an unresolved re-login. A differing login is genuinely
+                // unresolved — refuse rather than silently drop it. Mirrors the
+                // access-token comparison `classify_credentials_link` already uses;
+                // an unreadable side compares as `None`, preserving the prior
+                // "bail unless they match" conservatism.
+                let live_login = read_json_file::<ClaudeCredentials>(&link)
+                    .ok()
+                    .and_then(|c| c.access_token().map(str::to_string));
+                let target_login = read_json_file::<ClaudeCredentials>(&target)
+                    .ok()
+                    .and_then(|c| c.access_token().map(str::to_string));
+                if live_login != target_login {
                     anyhow::bail!(
                         "refusing to replace .credentials.json: live file differs from profile '{name}'; {} first",
                         crate::format::RESOLVE_IN_TUI
                     );
                 }
             }
+            // Preserve the live mcpOAuth blocks onto the incoming profile before
+            // the swap, so switching accounts keeps MCP-server auth intact.
+            carry_live_extra_into(&link, &target)?;
             std::fs::remove_file(&link).context("failed to remove old .credentials.json")?;
         }
 
@@ -913,10 +970,13 @@ pub(crate) fn force_snapshot_active_credentials(config: &mut AppConfig) -> Resul
 pub(crate) fn force_link_profile_credentials(name: &str) -> Result<()> {
     with_state_lock(|| {
         let link = claude_credentials_path()?;
+        let target = install_source_path(name)?;
         if link.symlink_metadata().is_ok() {
+            // Preserve the live mcpOAuth blocks onto the incoming profile before
+            // the swap, so switching accounts keeps MCP-server auth intact.
+            carry_live_extra_into(&link, &target)?;
             std::fs::remove_file(&link).context("failed to remove .credentials.json")?;
         }
-        let target = install_source_path(name)?;
         if target.exists() {
             if let Some(parent) = link.parent() {
                 std::fs::create_dir_all(parent)?;

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1500,6 +1500,33 @@ fn maybe_rewrite_config_toml(config_path: &Path, raw_config: &str, profile: &Pro
     }
 }
 
+/// Serialize `creds` for the profile store, preserving any non-login top-level
+/// blocks (notably `mcpOAuth`, the per-MCP-server logins) already present in the
+/// store file at `cred_path`. [`ClaudeCredentials`] models only the Claude login,
+/// so a plain re-serialize on a token refresh would drop those blocks; this
+/// re-attaches them. Keys serialized from `creds` win; existing extras are kept.
+fn serialize_credentials_preserving_extra(
+    creds: &ClaudeCredentials,
+    cred_path: &Path,
+) -> Result<String> {
+    let mut value = serde_json::to_value(creds).context("failed to serialize credentials")?;
+    let existing = read_json_file::<serde_json::Value>(cred_path).ok();
+    if let (Some(value_obj), Some(existing_obj)) = (
+        value.as_object_mut(),
+        existing.as_ref().and_then(serde_json::Value::as_object),
+    ) {
+        for (key, extra) in existing_obj {
+            if key == "claudeAiOauth" {
+                continue;
+            }
+            value_obj
+                .entry(key.clone())
+                .or_insert_with(|| extra.clone());
+        }
+    }
+    serde_json::to_string_pretty(&value).context("failed to serialize credentials")
+}
+
 pub(crate) fn save_profile(profile: &Profile) -> Result<()> {
     with_state_lock(|| {
         mkdir_700(&profile_dir(&profile.name)?)?;
@@ -1508,8 +1535,10 @@ pub(crate) fn save_profile(profile: &Profile) -> Result<()> {
         // not be lost to a config.toml write failure.
         let cred_path = profile_credentials_path(&profile.name)?;
         match &profile.credentials {
-            Some(creds) => atomic_write_600(&cred_path, serde_json::to_string_pretty(creds)?)
-                .context("failed to write credentials.json")?,
+            Some(creds) => {
+                let bytes = serialize_credentials_preserving_extra(creds, &cred_path)?;
+                atomic_write_600(&cred_path, bytes).context("failed to write credentials.json")?
+            }
             None if cred_path.exists() => {
                 std::fs::remove_file(&cred_path).context("failed to remove credentials.json")?
             }

--- a/tests/inline/claude.rs
+++ b/tests/inline/claude.rs
@@ -1410,3 +1410,209 @@ fn a_clauth_symlink_under_a_flipped_install_source_is_not_unsaved() {
         "a dangling clauth symlink is a store slot, not an unsaved login"
     );
 }
+
+// ---------------------------------------------------------------------------
+// mcpOAuth preservation. `~/.claude/.credentials.json` also holds each MCP
+// server's OAuth login (`mcpOAuth`), which is independent of the Claude account;
+// an account switch must not drop them. Every token below is synthetic.
+// ---------------------------------------------------------------------------
+
+/// A synthetic live-credentials body: a Claude login plus one MCP-server login.
+fn live_with_mcp(login: &str, mcp_token: &str) -> serde_json::Value {
+    serde_json::json!({
+        "claudeAiOauth": { "accessToken": login },
+        "mcpOAuth": { "linear": { "accessToken": mcp_token } }
+    })
+}
+
+#[test]
+fn carry_copies_mcp_oauth_and_leaves_the_target_login_untouched() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let live = dir.path().join("live.json");
+    let target = dir.path().join("credentials.json");
+    fs::write(
+        &live,
+        serde_json::to_vec(&live_with_mcp("live-login", "mock-linear")).unwrap(),
+    )
+    .expect("write live");
+    // Target store is a fresh browser login: a Claude login, no mcpOAuth.
+    fs::write(
+        &target,
+        serde_json::to_vec(
+            &serde_json::json!({ "claudeAiOauth": { "accessToken": "target-login" } }),
+        )
+        .unwrap(),
+    )
+    .expect("write target");
+
+    carry_live_extra_into(&live, &target).expect("carry");
+
+    let got: serde_json::Value =
+        serde_json::from_slice(&fs::read(&target).expect("read target")).expect("parse");
+    assert_eq!(
+        got["mcpOAuth"]["linear"]["accessToken"], "mock-linear",
+        "mcpOAuth carried onto the incoming profile"
+    );
+    assert_eq!(
+        got["claudeAiOauth"]["accessToken"], "target-login",
+        "the incoming account's own login is never overwritten by the live one"
+    );
+}
+
+#[test]
+fn carry_leaves_target_blocks_the_live_file_lacks() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let live = dir.path().join("live.json");
+    let target = dir.path().join("credentials.json");
+    // Live carries no mcpOAuth at all.
+    fs::write(
+        &live,
+        serde_json::to_vec(
+            &serde_json::json!({ "claudeAiOauth": { "accessToken": "live-login" } }),
+        )
+        .unwrap(),
+    )
+    .expect("write live");
+    fs::write(
+        &target,
+        serde_json::to_vec(&serde_json::json!({
+            "claudeAiOauth": { "accessToken": "target-login" },
+            "mcpOAuth": { "sentry": { "accessToken": "mock-sentry" } }
+        }))
+        .unwrap(),
+    )
+    .expect("write target");
+
+    carry_live_extra_into(&live, &target).expect("carry");
+
+    let got: serde_json::Value =
+        serde_json::from_slice(&fs::read(&target).expect("read target")).expect("parse");
+    assert_eq!(
+        got["mcpOAuth"]["sentry"]["accessToken"], "mock-sentry",
+        "a block the live file lacks is left as the target had it"
+    );
+}
+
+#[test]
+fn carry_skips_a_non_oauth_store() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let live = dir.path().join("live.json");
+    let target = dir.path().join("session-token.json");
+    fs::write(
+        &live,
+        serde_json::to_vec(&live_with_mcp("live-login", "mock-linear")).unwrap(),
+    )
+    .expect("write live");
+    let sidecar = serde_json::json!({ "sessionToken": "mock-static-token" });
+    fs::write(&target, serde_json::to_vec(&sidecar).unwrap()).expect("write sidecar");
+
+    carry_live_extra_into(&live, &target).expect("carry");
+
+    let got: serde_json::Value =
+        serde_json::from_slice(&fs::read(&target).expect("read target")).expect("parse");
+    assert_eq!(
+        got, sidecar,
+        "a session-token store has no claudeAiOauth and is left untouched"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn switching_accounts_preserves_mcp_oauth_end_to_end() {
+    let _home = HomeSandbox::new();
+
+    // Two OAuth profiles, each login-only in its store (as a browser login lands).
+    let mut a = crate::profile::Profile::new("a".to_string(), None, None);
+    a.credentials = Some(creds("login-a", Some("refresh-a")));
+    crate::profile::save_profile(&a).expect("save a");
+    let mut b = crate::profile::Profile::new("b".to_string(), None, None);
+    b.credentials = Some(creds("login-b", Some("refresh-b")));
+    crate::profile::save_profile(&b).expect("save b");
+
+    // Make A live, then simulate Claude Code authenticating an MCP server: it
+    // writes an mcpOAuth block through clauth's symlink into A's store.
+    force_link_profile_credentials("a").expect("link a");
+    let live_path = claude_credentials_path().expect("creds path");
+    let mut live: serde_json::Value =
+        serde_json::from_slice(&fs::read(&live_path).expect("read live")).expect("parse live");
+    live["mcpOAuth"] = serde_json::json!({ "linear": { "accessToken": "mock-linear" } });
+    fs::write(&live_path, serde_json::to_vec(&live).unwrap()).expect("write live mcp");
+
+    // Switch to B.
+    force_link_profile_credentials("b").expect("link b");
+
+    // The live credential now resolves to B's login AND still carries mcpOAuth.
+    let after: serde_json::Value =
+        serde_json::from_slice(&fs::read(&live_path).expect("read after")).expect("parse after");
+    assert_eq!(
+        after["claudeAiOauth"]["accessToken"], "login-b",
+        "the switch installed account B's login"
+    );
+    assert_eq!(
+        after["mcpOAuth"]["linear"]["accessToken"], "mock-linear",
+        "the MCP-server login survived the account switch"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn link_adopts_a_matching_login_and_preserves_mcp_oauth() {
+    let _home = HomeSandbox::new();
+    // Profile "main" holds a login-only store — exactly how a snapshot of the live
+    // account records it, since the typed model drops mcpOAuth.
+    let mut main = crate::profile::Profile::new("main".to_string(), None, None);
+    main.credentials = Some(creds("acct-login", Some("acct-refresh")));
+    crate::profile::save_profile(&main).expect("save main");
+
+    // The live file is the SAME account (an untracked regular file) carrying an
+    // mcpOAuth block — the state that made the byte-compare guard falsely refuse.
+    let live_path = claude_credentials_path().expect("creds path");
+    std::fs::create_dir_all(live_path.parent().expect("parent")).expect("mkdir");
+    std::fs::write(
+        &live_path,
+        serde_json::to_vec(&serde_json::json!({
+            "claudeAiOauth": { "accessToken": "acct-login" },
+            "mcpOAuth": { "linear": { "accessToken": "mock-linear" } }
+        }))
+        .unwrap(),
+    )
+    .expect("write live");
+
+    // Must NOT refuse (same login), and must carry mcpOAuth onto the store.
+    link_profile_credentials("main").expect("link adopts a matching login");
+
+    let after: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&live_path).expect("read after")).expect("parse");
+    assert_eq!(after["claudeAiOauth"]["accessToken"], "acct-login");
+    assert_eq!(
+        after["mcpOAuth"]["linear"]["accessToken"], "mock-linear",
+        "mcpOAuth survived the adoption link"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn link_still_refuses_a_different_live_login() {
+    let _home = HomeSandbox::new();
+    let mut other = crate::profile::Profile::new("other".to_string(), None, None);
+    other.credentials = Some(creds("other-login", Some("other-refresh")));
+    crate::profile::save_profile(&other).expect("save other");
+
+    // Live is an unresolved DIFFERENT account — a CC re-login the user hasn't saved.
+    let live_path = claude_credentials_path().expect("creds path");
+    std::fs::create_dir_all(live_path.parent().expect("parent")).expect("mkdir");
+    std::fs::write(
+        &live_path,
+        serde_json::to_vec(
+            &serde_json::json!({ "claudeAiOauth": { "accessToken": "unsaved-live-login" } }),
+        )
+        .unwrap(),
+    )
+    .expect("write live");
+
+    let err = link_profile_credentials("other").expect_err("must refuse a different login");
+    assert!(
+        err.to_string().contains("refusing to replace"),
+        "the guard still protects an unresolved different login: {err}"
+    );
+}

--- a/tests/inline/profile.rs
+++ b/tests/inline/profile.rs
@@ -1845,3 +1845,38 @@ check_scoped = false
     assert!(!loaded.check_weekly, "an explicit false survives the load");
     assert!(!loaded.check_scoped, "an explicit false survives the load");
 }
+
+/// `save_profile` must not drop non-login blocks (e.g. `mcpOAuth`) that a Claude
+/// login-token refresh rewrites over — those are per-MCP-server logins
+/// independent of the account. Synthetic tokens only.
+#[test]
+fn save_profile_preserves_mcp_oauth_across_a_login_refresh() {
+    let _home = HomeSandbox::new();
+
+    let mut profile = Profile::new("acct".to_string(), None, None);
+    profile.credentials = Some(pair("login-v1", "refresh-v1"));
+    save_profile(&profile).expect("save v1");
+
+    // Claude Code authenticates an MCP server, writing an mcpOAuth block into the
+    // store file alongside the login.
+    let cred_path = profile_credentials_path("acct").expect("cred path");
+    let mut stored: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&cred_path).expect("read store")).expect("parse");
+    stored["mcpOAuth"] = serde_json::json!({ "linear": { "accessToken": "mock-linear" } });
+    std::fs::write(&cred_path, serde_json::to_vec(&stored).unwrap()).expect("write mcp block");
+
+    // A Claude login-token rotation re-saves the profile with a new login.
+    profile.credentials = Some(pair("login-v2", "refresh-v2"));
+    save_profile(&profile).expect("save v2");
+
+    let after: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&cred_path).expect("read after")).expect("parse");
+    assert_eq!(
+        after["claudeAiOauth"]["accessToken"], "login-v2",
+        "the Claude login rotated to v2"
+    );
+    assert_eq!(
+        after["mcpOAuth"]["linear"]["accessToken"], "mock-linear",
+        "the MCP-server login survived the login refresh"
+    );
+}


### PR DESCRIPTION
> **operator asked:** "can't we just update the clauth code to copy over the mcp oauth?" — make account switching stop wiping MCP-server logins. The ask evolved: first run the patched build locally, then (once it was working) open this upstream because it's a real bug others hit.

clauth's account switch drops every `mcpOAuth` block from `~/.claude/.credentials.json`, silently logging you out of all MCP servers on each switch. `ClaudeCredentials` models only `claudeAiOauth`, so the snapshot-then-symlink switch installs a login-only store and the per-MCP-server logins — which are independent of the Claude account — are lost. Adoption ("new from current profile" onto an existing untracked login) also hard-refused, because the switch guard byte-compared the whole live file against the login-only store and tripped on the mcpOAuth difference.

This preserves non-login top-level blocks without widening the typed model:

- `save_profile` re-attaches any non-login keys already in the store, so a login-token refresh no longer drops them.
- switching (`link_` / `force_link_profile_credentials`) carries the live file's non-login blocks onto the incoming profile before the swap.
- the `link_profile_credentials` refuse-guard compares the login access token (matching what `classify_credentials_link` already does) instead of the whole file, so a live file that differs only in mcpOAuth is no longer a false refusal; a genuinely different login is still refused.

The login (`claudeAiOauth`) is never altered, and the blocks preserved are per-MCP-server logins that don't belong to any one Claude account. I deliberately did not add a field to `ClaudeCredentials`, so its ~35 constructors are untouched. I didn't find docs describing this behavior, so there was nothing to update.

## agent

- Claude Code (Claude Opus 4.8), operated by @theo-nash
- ran: `cargo test` → 1786 pass, 1 fail (`reload_fingerprint_ignores_a_bare_session_token_stamp`) which also fails on unmodified `mommy` — a filesystem mtime-resolution flake on my WSL2 box, not from this change; `cargo fmt --check` clean; `cargo clippy --all-targets` no warnings in the changed files. Added 6 tests (synthetic tokens only): the carry helper, save-refresh preservation, an end-to-end switch, the adoption link, and the retained different-login refusal. operator verified: ran the patched build on a real two-account setup — an actual account switch preserved all 12 of their mcpOAuth blocks.
- unsure: narrowing the `link_profile_credentials` refuse-guard from a whole-file compare to a login-token compare is the one change to a safety guard — it matches `classify_credentials_link`'s existing access-token comparison and the `switch_replaces_active_account_mirror_without_refusing` test still passes, but it's worth a maintainer's eye. Separately, I chose a localized JSON merge over adding a flattened `extra` field to `ClaudeCredentials`; the typed approach may fit the codebase better but would churn ~35 constructors.
