### PR TITLE
fix(keychain): pick the transport by size, never let security truncate

### DIFF
--- a/src/keychain.rs
+++ b/src/keychain.rs
@@ -194,6 +194,55 @@ fn run_with_deadline(
 /// Keychain generic-password service Claude Code reads/writes for its login.
 const SERVICE: &str = "Claude Code-credentials";
 
+/// Longest command line `security -i`'s tokenizer reads as ONE command.
+///
+/// Measured on macOS 15 / Darwin 25 against a throwaway service: a 3900-byte
+/// value round-trips byte-identical, a 4100-byte value does NOT. Past the
+/// ceiling `security` does not refuse — it splits the line, executes the head
+/// with a TRUNCATED `-w` value, and reports the tail as `unknown command`. The
+/// item is left holding the truncated JSON, so a write that overruns this
+/// silently destroys whatever the item held.
+///
+/// This mattered nowhere until the mirror started preserving Claude Code's
+/// sibling keys: a login-only blob is 1-2 KB and never came close, while a blob
+/// carrying `mcpOAuth` for a dozen-plus OAuth MCP servers clears it easily.
+const SECURITY_STDIN_LINE_MAX: usize = 4096;
+
+/// Largest value that survives the argv transport intact, same measurement run:
+/// 64 KiB round-trips, 128 KiB does not. NOT an `ARG_MAX` limit — that is 1 MiB
+/// on this host — so the ceiling is `security`/Keychain's own. A blob past this
+/// is refused rather than written, because every transport we have would mangle
+/// it and a mangled item is a lost login plus lost MCP servers.
+const SECURITY_ARGV_VALUE_MAX: usize = 64 * 1024;
+
+/// How [`put_blob_at`] hands one write to `security`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PutTransport {
+    /// `security -i`, command line over stdin. Keeps the token out of this
+    /// process's argv, hence out of Endpoint Security exec logging (PR #21).
+    Stdin,
+    /// `security add-generic-password …` with the value as a real argv word.
+    /// Gives up the EDR-log property to stay under [`SECURITY_STDIN_LINE_MAX`];
+    /// argv is still same-UID-or-root only, the tradeoff PR #21 called already
+    /// accepted. Correctness wins: the alternative is a truncated item.
+    Argv,
+}
+
+/// Pick the transport for a `-i` command line of `line_len` bytes carrying a
+/// `value_len`-byte password. PURE, so the decision and both ceilings are pinned
+/// without a Keychain.
+fn put_transport(line_len: usize, value_len: usize) -> Result<PutTransport> {
+    if line_len <= SECURITY_STDIN_LINE_MAX {
+        return Ok(PutTransport::Stdin);
+    }
+    if value_len <= SECURITY_ARGV_VALUE_MAX {
+        return Ok(PutTransport::Argv);
+    }
+    anyhow::bail!(
+        "refusing to write a {value_len}-byte Keychain item: past the {SECURITY_ARGV_VALUE_MAX}-byte          ceiling every `security` transport truncates instead of failing, which would destroy the          login and any MCP server logins stored beside it"
+    )
+}
+
 /// `security(1)` exit status for `errSecItemNotFound` (-25300). Returned when no
 /// matching item exists; treated as "absent" (`None`) on read and a no-op on delete.
 const EXIT_ITEM_NOT_FOUND: i32 = 44;
@@ -433,10 +482,32 @@ fn put_blob_at(service: &str, account: &str, blob: &Value) -> Result<()> {
         security_quote(account)?,
         security_quote(&json)?,
     );
-    let mut cmd = Command::new(SECURITY_BIN);
-    cmd.arg("-i");
-    let output = run_with_deadline(cmd, security_deadline(), Some(&line))
-        .with_context(|| format!("failed to run {SECURITY_BIN} add-generic-password"))?;
+    // Past `-i`'s line ceiling the tokenizer truncates the value instead of
+    // refusing, so the transport is chosen by size, not by preference.
+    let output = match put_transport(line.len(), json.len())? {
+        PutTransport::Stdin => {
+            let mut cmd = Command::new(SECURITY_BIN);
+            cmd.arg("-i");
+            run_with_deadline(cmd, security_deadline(), Some(&line))
+        }
+        PutTransport::Argv => {
+            // No `security_quote` here: argv words reach `security` verbatim, so
+            // the `-i` tokenizer's escaping would be written INTO the password.
+            let mut cmd = Command::new(SECURITY_BIN);
+            cmd.args([
+                "add-generic-password",
+                "-U",
+                "-s",
+                service,
+                "-a",
+                account,
+                "-w",
+                &json,
+            ]);
+            run_with_deadline(cmd, security_deadline(), None)
+        }
+    }
+    .with_context(|| format!("failed to run {SECURITY_BIN} add-generic-password"))?;
     if output.status.success() {
         Ok(())
     } else {

--- a/tests/inline/keychain.rs
+++ b/tests/inline/keychain.rs
@@ -10,8 +10,9 @@
 //! touches the Keychain.
 
 use super::{
-    Keep, delete_at, keychain_service_for_config_dir, merge_and_put_at, merge_write, merged_blob,
-    put_blob_at, read_blob_at, run_with_deadline, security_quote,
+    Keep, PutTransport, SECURITY_ARGV_VALUE_MAX, SECURITY_STDIN_LINE_MAX, delete_at,
+    keychain_service_for_config_dir, merge_and_put_at, merge_write, merged_blob, put_blob_at,
+    put_transport, read_blob_at, run_with_deadline, security_quote,
 };
 use crate::profile::{ClaudeCredentials, OAuthToken};
 use std::path::Path;
@@ -488,4 +489,64 @@ fn keychain_service_canonicalization_resolves_dot_dot() {
         via_dotdot, direct,
         "`sub/..` must canonicalize to the parent directory"
     );
+}
+
+// ── the transport ceilings: `security` truncates instead of refusing ──────────
+//
+// `security -i` reads ONE command per line into a bounded buffer. Past it the
+// value is silently cut and the tail parsed as another command, leaving the item
+// holding truncated JSON -- a destroyed login AND destroyed `mcpOAuth`. Harmless
+// while the mirror wrote a 1-2 KB login-only blob; reachable now that the blob
+// carries Claude Code's sibling keys.
+
+#[test]
+fn stdin_carries_a_line_up_to_the_ceiling() {
+    assert_eq!(
+        put_transport(SECURITY_STDIN_LINE_MAX, 100).expect("at the ceiling"),
+        PutTransport::Stdin,
+    );
+    assert_eq!(
+        put_transport(SECURITY_STDIN_LINE_MAX + 1, 100).expect("one past it"),
+        PutTransport::Argv,
+        "one byte past the ceiling must leave the stdin transport, not truncate",
+    );
+}
+
+#[test]
+fn argv_takes_over_up_to_its_own_ceiling() {
+    assert_eq!(
+        put_transport(1_000_000, SECURITY_ARGV_VALUE_MAX).expect("at the argv ceiling"),
+        PutTransport::Argv,
+    );
+    // Past BOTH ceilings there is no intact transport left, so refuse. Writing
+    // anyway is what destroys the item.
+    assert!(put_transport(1_000_000, SECURITY_ARGV_VALUE_MAX + 1).is_err());
+}
+
+// KC-3 -- the ceiling through the REAL `security`, on a throwaway service. Sized
+// like an operator carrying a dozen-plus OAuth MCP servers beside the login: the
+// case that used to come back truncated.
+#[test]
+#[ignore = "touches the real login Keychain (throwaway service); macOS re-prompts each rebuild — run explicitly with --ignored"]
+fn a_blob_past_the_stdin_ceiling_round_trips_intact() {
+    use serde_json::json;
+
+    let service = format!("clauth-ceiling-test-{}", std::process::id());
+    let account = "clauth-test-account";
+    delete_at(&service, account).expect("pre-clean");
+
+    for value_len in [SECURITY_STDIN_LINE_MAX - 200, SECURITY_STDIN_LINE_MAX + 200, 32 * 1024] {
+        let blob = json!({
+            "claudeAiOauth": { "accessToken": "a".repeat(200) },
+            "mcpOAuth": { "srv": { "accessToken": "m".repeat(value_len) } },
+        });
+        put_blob_at(&service, account, &blob).expect("write");
+        assert_eq!(
+            read_blob_at(&service, account).expect("read").as_ref(),
+            Some(&blob),
+            "a {value_len}-byte blob came back changed -- the transport truncated it",
+        );
+    }
+
+    delete_at(&service, account).expect("cleanup");
 }


### PR DESCRIPTION
## The defect

`security -i` reads one command per line into a bounded buffer. Past that buffer it does **not** refuse. It splits the line, runs the head with a **truncated** `-w` value, and reports the tail as `unknown command`. The item is left holding truncated JSON.

I hit this as a real data loss on macOS 15 / Darwin 25, on an account with ~20 OAuth MCP servers. The write meant to *preserve* `mcpOAuth` is the one that destroyed it, along with `claudeAiOauth` beside it, leaving the item unparseable:

```
Error: Keychain write failed (security exit 1): security: unknown command "CJuYW1lIjoi…"
```

That fragment is the middle of a JWT from the blob being written.

## Measurement

Throwaway service, same host:

| payload | `security -i` | argv |
|---|---|---|
| 3900 B | intact | intact |
| 4100 B | **BROKEN** | intact |
| 32000 B | **BROKEN** | intact |
| 64000 B | — | intact |
| 128000 B | — | **BROKEN** |

So `-i`'s ceiling is a 4096-byte command line, and argv holds to 64 KiB. argv's ceiling is not `ARG_MAX` — that is 1 MiB here — but `security`/Keychain's own.

## Why it appeared now

Unreachable while the mirror wrote a login-only blob: 1–2 KB never came near 4096. #64 changed the size class by preserving Claude Code's sibling keys, and a blob carrying `mcpOAuth` for a dozen-plus OAuth MCP servers clears the ceiling easily. #21 and #64 are each correct alone and collide together.

`run_with_deadline`'s comment reasons about the 64 KB pipe buffer, which is the wrong limit — the pipe is fine, the line tokenizer is not.

## The change

Choose the transport by size: `-i` while the line fits, argv above it, refuse past 64 KiB rather than write something `security` will mangle.

The argv fallback gives up the Endpoint-Security-log property #21 won, and only for blobs too large to keep it. argv stays same-UID-or-root only — the exposure #21 recorded as already accepted (TECH-9 #17). A truncated item is a lost login *and* lost MCP servers, so correctness takes precedence. Happy to gate the fallback behind a setting, or to move the whole write to `SecItemUpdate`, if you would rather not lose the property at all.

## Tests

- `stdin_carries_a_line_up_to_the_ceiling` / `argv_takes_over_up_to_its_own_ceiling` — pure, pins both ceilings and the refusal.
- **KC-3** `a_blob_past_the_stdin_ceiling_round_trips_intact` — drives a realistically sized blob through the real `security` on a throwaway service. **Fails on the parent commit, passes here.**

Full suite: 2449 passed, 4 ignored. `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)